### PR TITLE
textile docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+
+.github
+.circleci
+dist
+examples
+.threads*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+FROM golang:1.13.1-stretch
+MAINTAINER Andrew Hill <andrew@textile.io>
+
+# This is (in large part) copied (with love) from
+# https://hub.docker.com/r/ipfs/go-ipfs/dockerfile
+
+# Get source
+ENV SRC_DIR /textile
+
+# Download packages first so they can be cached.
+COPY go.mod go.sum $SRC_DIR/
+RUN cd $SRC_DIR \
+  && go mod download
+
+COPY . $SRC_DIR
+
+# build source
+RUN cd $SRC_DIR \
+  && go install github.com/textileio/textile/cmd/textiled
+
+# Get su-exec, a very minimal tool for dropping privileges,
+# and tini, a very minimal init daemon for containers
+ENV SUEXEC_VERSION v0.2
+ENV TINI_VERSION v0.16.1
+RUN set -x \
+  && cd /tmp \
+  && git clone https://github.com/ncopa/su-exec.git \
+  && cd su-exec \
+  && git checkout -q $SUEXEC_VERSION \
+  && make \
+  && cd /tmp \
+  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
+  && chmod +x tini
+
+# Get the TLS CA certificates, they're not provided by busybox.
+RUN apt-get update && apt-get install -y ca-certificates
+
+# Now comes the actual target image, which aims to be as small as possible.
+FROM busybox:1-glibc
+MAINTAINER Sander Pick <sander@textile.io>
+
+# Get the threads binary, entrypoint script, and TLS CAs from the build container.
+ENV SRC_DIR /textile
+COPY --from=0 /go/bin/textiled /usr/local/bin/textiled
+COPY --from=0 $SRC_DIR/bin/container_daemon /usr/local/bin/start_textile
+COPY --from=0 /tmp/su-exec/su-exec /sbin/su-exec
+COPY --from=0 /tmp/tini /sbin/tini
+COPY --from=0 /etc/ssl/certs /etc/ssl/certs
+
+# This shared lib (part of glibc) doesn't seem to be included with busybox.
+# COPY --from=0 /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
+
+# Create the fs-repo directory
+ENV TEXTILE_REPO /data/textile
+RUN mkdir -p $TEXTILE_REPO \
+  && adduser -D -h $TEXTILE_REPO -u 1000 -G users textile \
+  && chown -R textile:users $TEXTILE_REPO
+
+# Switch to a non-privileged user
+USER textile
+
+# Expose the fs-repo as a volume.
+# start_threads initializes an fs-repo if none is mounted.
+# Important this happens after the USER directive so permission are correct.
+VOLUME $TEXTILE_REPO
+
+EXPOSE 3006
+
+# This just makes sure that:
+# 1. There's an fs-repo, and initializes one if there isn't.
+# 2. The API and Gateway are accessible from outside the container.
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/start_textile"]
+
+# Execute the daemon subcommand by default
+CMD ["--repo=/data/textile", "--addrApi=/ip4/0.0.0.0/tcp/3006"]

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
 textile:
 	go install ./...
+
+docker:
+	$(eval VERSION := $(shell git --no-pager describe --abbrev=0 --tags --always))
+	docker build -t textiled:$(VERSION:v%=%) .

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -22,7 +22,7 @@ if [[ -z "${DOCKER_COMPOSE}" ]]; then
 else
 	IP=$(ping -c 2 textile_threads | head -1 | awk -F "(" '{print $2}' | awk -F ")" '{print $1}')
 	echo "Threads service found: $IP"
-	exec /usr/local/bin/textiled --addrThreadsApi=/ip4/$IP/tcp/9090
+	exec /usr/local/bin/textiled --addrThreadsHostProxy=/ip4/$IP/tcp/4006 --addrThreadsHostProxy=/ip4/$IP/tcp/5050 --addrThreadsApi=/ip4/$IP/tcp/9090 --addrThreadsApiProxy=/ip4/$IP/tcp/9091
 fi
 
 

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -12,4 +12,17 @@ if [ $(id -u) -eq 0 ]; then
 	exec su-exec "$user" "$0" "$@"
 fi
 
-exec textiled "$@"
+# ensure that threads service boots
+sleep 2
+
+# https://docs.docker.com/network/network-tutorial-standalone/
+# clearest way i could find to programatically set the IP address of the service
+if [[ -z "${DOCKER_COMPOSE}" ]]; then
+	exec /usr/local/bin/textiled "$@"
+else
+	IP=$(ping -c 2 textile_threads | head -1 | awk -F "(" '{print $2}' | awk -F ")" '{print $1}')
+	echo "Threads service found: $IP"
+	exec /usr/local/bin/textiled --addrThreadsApi=/ip4/$IP/tcp/9090
+fi
+
+

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -1,0 +1,15 @@
+#!/bin/sh
+# this file requires sh over bash:
+set -e
+user=textile
+repo="$TEXTILE_REPO"
+
+if [ $(id -u) -eq 0 ]; then
+	echo "Changing user to $user"
+	# ensure folder is writable
+	su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
+	# restart script with new privileges
+	exec su-exec "$user" "$0" "$@"
+fi
+
+exec textiled "$@"

--- a/core/core.go
+++ b/core/core.go
@@ -13,7 +13,6 @@ import (
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	"github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
-	threadsapi "github.com/textileio/go-textile-threads/api"
 	threadsclient "github.com/textileio/go-textile-threads/api/client"
 	es "github.com/textileio/go-textile-threads/eventstore"
 	"github.com/textileio/go-textile-threads/util"
@@ -37,7 +36,6 @@ type Textile struct {
 
 	threadservice es.ThreadserviceBoostrapper
 
-	threadsServer *threadsapi.Server
 	threadsClient *threadsclient.Client
 
 	server *api.Server
@@ -84,12 +82,6 @@ func NewTextile(conf Config) (*Textile, error) {
 		return nil, err
 	}
 
-	threadsServer, err := threadsapi.NewServer(context.Background(), threadservice, threadsapi.Config{
-		RepoPath:  conf.RepoPath,
-		Addr:      conf.AddrThreadsApi,
-		ProxyAddr: conf.AddrThreadsApiProxy,
-		Debug:     conf.Debug,
-	})
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +128,6 @@ func NewTextile(conf Config) (*Textile, error) {
 		ipfs: ipfs,
 
 		threadservice: threadservice,
-		threadsServer: threadsServer,
 		threadsClient: threadsClient,
 
 		server: server,
@@ -151,7 +142,6 @@ func (t *Textile) Close() error {
 	if err := t.threadservice.Close(); err != nil {
 		return err
 	}
-	t.threadsServer.Close()
 	t.server.Close()
 	return t.ds.Close()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: "textile_threads"
     build: 
       context: ../go-textile-threads/.
-    command: "daemon --repo=/data/threads --hostAddr=/ip4/0.0.0.0/tcp/4006 --hostProxyAddr=/ip4/0.0.0.0/tcp/5050 --apiAddr=/ip4/0.0.0.0/tcp/9090 --apiProxyAddr=/ip4/127.0.0.1/tcp/9091"
+    command: "daemon --repo=/data/threads --hostAddr=/ip4/127.0.0.1/tcp/4006 --hostProxyAddr=/ip4/127.0.0.1/tcp/5050 --apiAddr=/ip4/127.0.0.1/tcp/9090 --apiProxyAddr=/ip4/127.0.0.1/tcp/9091"
     ports:
       - "4006:4006"
       - "5050:5050"
@@ -20,5 +20,4 @@ services:
     links: 
       - textile_threads
     ports:
-      - target: 3006
-        published: 3006
+      - "3006:3006"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.7"
+services:
+  textile_threads:
+    container_name: "textile_threads"
+    build: 
+      context: ../go-textile-threads/.
+    command: "daemon --repo=/data/threads --hostAddr=/ip4/0.0.0.0/tcp/4006 --hostProxyAddr=/ip4/0.0.0.0/tcp/5050 --apiAddr=/ip4/0.0.0.0/tcp/9090 --apiProxyAddr=/ip4/127.0.0.1/tcp/9091"
+    ports:
+      - "4006:4006"
+      - "5050:5050"
+      - "9090:9090"
+      - "9091:9091"
+  textile_daemon:
+    container_name: "textile_daemon"
+    build: .
+    environment:
+      DOCKER_COMPOSE: "true"
+    depends_on:
+      - textile_threads
+    links: 
+      - textile_threads
+    ports:
+      - target: 3006
+        published: 3006


### PR DESCRIPTION
with this setup, you can run,

`docker-compose -f docker-compose.yml up` from the project dir and it will stand up the threads service + a textiled server in docker. 

i've pulled the thread server out of this project, so instead it expects to always just talk to it over grpc. that feels right still.

but probably, the way you'll want to run the project is just,

1. in my PR of go-textile-threads (https://github.com/textileio/go-textile-threads/pull/169) we'll start pushing tag builds to docker-hub
2. then locally, you can just do `docker run -p 9090:9090 -i textile/threads-service` (or whatever name)
3. then in this project just fire it up with `textiled --addrThreadsApi=/ip4/0.0.0.0/tcp/9090` since the port will be available over localhost like that, it'll all just work.