### PR TITLE
cleanup verification await

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -34,7 +34,7 @@ func TestLogin(t *testing.T) {
 	t.Run("test login", func(t *testing.T) {
 		res := make(chan loginResponse)
 		go func() {
-			id, err := client.Login(context.Background(), "jon@doe.com", 5*time.Second)
+			id, err := client.Login(context.Background(), "jon@doe.com")
 			res <- loginResponse{
 				Token: id,
 				Error: err,

--- a/cmd/textile/login.go
+++ b/cmd/textile/login.go
@@ -38,7 +38,7 @@ var loginCmd = &cobra.Command{
 		s.Start()
 
 		ctx := context.Background()
-		token, err := client.Login(ctx, email, loginTimeout)
+		token, err := client.Login(ctx, email)
 		s.Stop()
 
 		if err != nil {

--- a/cmd/textile/main.go
+++ b/cmd/textile/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	logging "github.com/ipfs/go-log"
 	"github.com/spf13/cobra"
@@ -42,8 +41,6 @@ var (
 	}
 
 	client *api.Client
-
-	loginTimeout = time.Minute * 2
 )
 
 func init() {


### PR DESCRIPTION
fixes https://github.com/textileio/textile/issues/31

also cleans up the client timeout so it should fire cleanly before any other connection/context issues