### PR TITLE
flags: makes filecoin api address empty by default so not used

### DIFF
--- a/cmd/textiled/main.go
+++ b/cmd/textiled/main.go
@@ -71,7 +71,7 @@ var (
 		},
 		"addrFilecoinApi": {
 			Key:      "addr.filecoin.api",
-			DefValue: "/ip4/127.0.0.1/tcp/5002",
+			DefValue: "",
 		},
 		"dnsDomain": {
 			Key:      "dns.domain",


### PR DESCRIPTION
Signed-off-by: andrew <andrew@textile.io>