### PR TITLE
cli: cleanup team and project methods

### DIFF
--- a/cmd/textile/projects.go
+++ b/cmd/textile/projects.go
@@ -39,7 +39,7 @@ var projectsCmd = &cobra.Command{
 }
 
 var initProjectCmd = &cobra.Command{
-	Use:   "init",
+	Use:   "init [name]",
 	Short: "Init a new project",
 	Long:  `Initialize a new project.`,
 	Args:  cobra.ExactArgs(1),

--- a/cmd/textile/teams.go
+++ b/cmd/textile/teams.go
@@ -38,36 +38,23 @@ var teamsCmd = &cobra.Command{
 }
 
 var addTeamsCmd = &cobra.Command{
-	Use:   "add",
+	Use:   "add [name]",
 	Short: "Add team",
 	Long:  `Add a new team (interactive).`,
+	Args:  cobra.ExactArgs(1),
 	Run: func(c *cobra.Command, args []string) {
-		prompt := promptui.Prompt{
-			Label: "Enter a team name",
-			Validate: func(name string) error {
-				if len(name) < 3 {
-					return errors.New("name too short")
-				}
-				return nil
-			},
-		}
-		name, err := prompt.Run()
-		if err != nil {
-			cmd.End("")
-		}
-
 		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
 		if _, err := client.AddTeam(
 			ctx,
-			name,
+			args[0],
 			api.Auth{
 				Token: authViper.GetString("token"),
 			}); err != nil {
 			cmd.Fatal(err)
 		}
 
-		cmd.Success("Added new team %s", aurora.White(name).Bold())
+		cmd.Success("Added new team %s", aurora.White(args[0]).Bold())
 	},
 }
 


### PR DESCRIPTION
two changes here.

shows the arg required in the project init usage string,

```
Usage:
  textile projects init [name] [flags]
```

removes the prompt flow in the `textile team add` so that it works the same as `textile project init` where you just pass the arg. so new usage is,

```
Usage:
  textile teams add [name] [flags]
```

let me know if there was a strong preference for the old prompt flow of the second one, happy to rip that out if so