### PR TITLE
Rename js packages to match existing conventions

### DIFF
--- a/api/buckets/pb/javascript/package.json
+++ b/api/buckets/pb/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@textile/buckets-grpc",
   "version": "0.0.0",
-  "description": "Interfaces/classes for interacting with the Textile Buckets gRPC API.",
+  "description": "A client for interacting with the Textile Buckets gRPC API.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/textileio/textile.git"

--- a/api/buckets/pb/javascript/package.json
+++ b/api/buckets/pb/javascript/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@textile/buckets",
+  "name": "@textile/buckets-grpc",
   "version": "0.0.0",
-  "description": "A client for interacting with the Textile Buckets gRPC API.",
+  "description": "Interfaces/classes for interacting with the Textile Buckets gRPC API.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/textileio/textile.git"

--- a/api/hub/pb/javascript/package.json
+++ b/api/hub/pb/javascript/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@textile/hub",
+  "name": "@textile/hub-grpc",
   "version": "0.0.0",
-  "description": "A client for interacting with the Textile Hub gRPC API.",
+  "description": "Interfaces/classes for interacting with the Textile Hub gRPC API.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/textileio/textile.git"

--- a/api/hub/pb/javascript/package.json
+++ b/api/hub/pb/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@textile/hub-grpc",
   "version": "0.0.0",
-  "description": "Interfaces/classes for interacting with the Textile Hub gRPC API.",
+  "description": "A client for interacting with the Textile Hub gRPC API.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/textileio/textile.git"

--- a/api/users/pb/javascript/package.json
+++ b/api/users/pb/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@textile/users-grpc",
   "version": "0.0.0",
-  "description": "Interfaces/classes for interacting with the Textile Users gRPC API.",
+  "description": "A client for interacting with the Textile Users gRPC API.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/textileio/textile.git"

--- a/api/users/pb/javascript/package.json
+++ b/api/users/pb/javascript/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@textile/users",
+  "name": "@textile/users-grpc",
   "version": "0.0.0",
-  "description": "A client for interacting with the Textile Users gRPC API.",
+  "description": "Interfaces/classes for interacting with the Textile Users gRPC API.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/textileio/textile.git"


### PR DESCRIPTION
Tiny 'nit' PR. If there is an argument against this, that's also fine. We use `*-grpc` in our other JS libs, it it seemed like a good idea to do the same here. Also, seems useful to reserve the top-level lib names (`hub`, `user`, `buckets`) for those actual clients (if we ever needed them), plus this avoids confusion when folks are installing via npm (they might try to install @textile/hub and get something unexpected).