### PR TITLE
run dev locally in single commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,11 @@
 textile:
 	go install ./...
+
+local-up:
+	docker-compose -f docker-compose-dev.yml up
+
+local-stop:
+	docker-compose stop
+
+local-clean:
+	docker-compose down -v

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,27 @@
+version: "3"
+services:
+  textile:
+    build: .
+    environment:
+      - TXTL_ADDR_API=/ip4/0.0.0.0/tcp/3006
+      - TXTL_ADDR_API_PROXY=/ip4/0.0.0.0/tcp/3007
+      - TXTL_ADDR_THREADS_HOST=/ip4/0.0.0.0/tcp/4006
+      - TXTL_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8006
+      - TXTL_ADDR_MONGO_URI=mongodb://mongo:27017
+      - TXTL_ADDR_IPFS_API=/dns4/ipfs/tcp/5001
+      - TXTL_EMAIL_SESSION_SECRET=textilesession
+    ports:
+      - "127.0.0.1:3006:3006"
+      - "3007:3007"
+      - "4006:4006"
+      - "127.0.0.1:8006:8006"
+  mongo:
+    image: mongo:latest
+    ports:
+      - "127.0.0.1:27017:27017"
+  ipfs:
+    image: ipfs/go-ipfs:v0.5.0-rc2
+    ports:
+      - "4001:4001"
+      - "127.0.0.1:5001:5001"
+      - "8080:8080"


### PR DESCRIPTION
Created a `dev` compose file that doesn't rely on compiled `textile`, but local code. So you can change the code and run things again. (No .env things needed). This is a similar idea of the `make embed` in Powergate, which re-runs the docker-build on changed code.

The run is clean in the sense that *nothing* about the docker-compose run is mapped to the local HDD, all lives inside docker volumes.

I added new `make` commands:
- `make local-up`: spin up things with `textile` running local code.
- `make local-stop`: to stop things, but keep volumes (state).
- `make local-clean`: clean all things, so next `local-up` is a fresh world. We could go a step further and also do `rm -r ~/.textile` to rm any client folder... but preferred to leave the host folder untouched just in case the client wasn't being run with defaults.

My actual use:
`make local-up`
`tt --api "localhost:3006: init`
`tt buckets init`
...
eventually if want to start fresh: `make local-clean local-up`

Also, the email-session-secret is fixed so `init`ing can be done fast using `textilesession` as the email session for validating email.