### PR TITLE
IPNS: Use RSA keys which encode to shorter strings

### DIFF
--- a/api/buckets/service.go
+++ b/api/buckets/service.go
@@ -103,7 +103,7 @@ func (s *Service) createBucket(ctx context.Context, dbID thread.ID, dbToken thre
 		return nil, err
 	}
 
-	key, err := s.IPFSClient.Key().Generate(ctx, util.MakeToken(keyLen), opt.Key.Type(options.Ed25519Key))
+	key, err := s.IPFSClient.Key().Generate(ctx, util.MakeToken(keyLen), opt.Key.Type(options.RSAKey))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ed25519 keys base32-encode to length 65, which is too long for Cloudflare's CNAME name entry (max 63). 2048 bit RSA keys base32-encode to length 59.