### PR TITLE
Adds destroy bucket command and some other nits

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -94,6 +94,13 @@ func Message(format string, args ...interface{}) {
 	fmt.Println(aurora.Sprintf(aurora.BrightBlack("> "+format), args...))
 }
 
+func Warn(format string, args ...interface{}) {
+	if format == "" {
+		return
+	}
+	fmt.Println(aurora.Sprintf(aurora.Yellow("! "+format), args...))
+}
+
 func Success(format string, args ...interface{}) {
 	fmt.Println(aurora.Sprintf(aurora.Cyan("> Success! %s"),
 		aurora.Sprintf(aurora.BrightBlack(format), args...)))

--- a/cmd/tt/bucket.go
+++ b/cmd/tt/bucket.go
@@ -30,7 +30,7 @@ func init() {
 	initBucketCmd.PersistentFlags().String("org", "", "Org username")
 	initBucketCmd.PersistentFlags().Bool("public", false, "Allow public access")
 	initBucketCmd.PersistentFlags().String("thread", "", "Thread ID")
-	initBucketCmd.Flags().Bool("existing", false, "If set, initalizes from an existing remote bucket")
+	initBucketCmd.Flags().Bool("existing", false, "If set, initializes from an existing remote bucket")
 
 	if err := cmd.BindFlags(configViper, initBucketCmd, flags); err != nil {
 		cmd.Fatal(err)

--- a/cmd/tt/bucket.go
+++ b/cmd/tt/bucket.go
@@ -169,9 +169,20 @@ Existing configs will not be overwritten.
 			selected := selectThread("Buckets are written to a threadDB. Select or create a new one", aurora.Sprintf(
 				aurora.BrightBlack("> Selected threadDB {{ .ID | white | bold }}")), true)
 			if selected.ID == "Create new" {
+				if selected.Name == "" {
+					prompt := promptui.Prompt{
+						Label: "Enter a name for your new threadDB (optional)",
+					}
+					var err error
+					selected.Name, err = prompt.Run()
+					if err != nil {
+						cmd.End("")
+					}
+				}
 				ctx, cancel := threadCtx(cmdTimeout)
 				defer cancel()
 				dbID = thread.NewIDV1(thread.Raw, 32)
+				ctx = common.NewThreadNameContext(ctx, selected.Name)
 				if err := threads.NewDB(ctx, dbID); err != nil {
 					cmd.Fatal(err)
 				}

--- a/cmd/tt/bucket.go
+++ b/cmd/tt/bucket.go
@@ -405,7 +405,7 @@ These 'push' commands result in the following bucket structures.
 		}
 
 		prompt := promptui.Prompt{
-			Label:     fmt.Sprintf("Push %d files?", len(names)),
+			Label:     fmt.Sprintf("Push %d files", len(names)),
 			IsConfirm: true,
 		}
 		if _, err := prompt.Run(); err != nil {
@@ -624,7 +624,7 @@ var destroyBucketCmd = &cobra.Command{
 		}
 	},
 	Run: func(c *cobra.Command, args []string) {
-		cmd.Message("This action cannot be undone. The bucket and all associated data will be permanently deleted.")
+		cmd.Warn("%s", aurora.Red("This action cannot be undone. The bucket and all associated data will be permanently deleted."))
 		prompt := promptui.Prompt{
 			Label:     fmt.Sprintf("Are you absolutely sure"),
 			IsConfirm: true,

--- a/cmd/tt/destroy.go
+++ b/cmd/tt/destroy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/cmd"
@@ -25,7 +26,7 @@ var destroyCmd = &cobra.Command{
 			cmd.Fatal(err)
 		}
 
-		cmd.Message("Are you absolutely sure? This action cannot be undone. Your account and all associated data will be permanently deleted.")
+		cmd.Warn("%s", aurora.Red("Are you absolutely sure? This action cannot be undone. Your account and all associated data will be permanently deleted."))
 		prompt := promptui.Prompt{
 			Label: fmt.Sprintf("Please type '%s' to confirm", who.Username),
 			Validate: func(s string) error {

--- a/cmd/tt/destroy.go
+++ b/cmd/tt/destroy.go
@@ -18,20 +18,33 @@ var destroyCmd = &cobra.Command{
 	Short: "Destroy your account",
 	Long:  `Destroy your account and all associated data.`,
 	Run: func(c *cobra.Command, args []string) {
+		ctx, cancel := authCtx(cmdTimeout)
+		defer cancel()
+		who, err := hub.GetSessionInfo(ctx)
+		if err != nil {
+			cmd.Fatal(err)
+		}
+
+		cmd.Message("Are you absolutely sure? This action cannot be undone. Your account and all associated data will be permanently deleted.")
 		prompt := promptui.Prompt{
-			Label:     fmt.Sprintf("Delete account and all associated data?"),
-			IsConfirm: true,
+			Label: fmt.Sprintf("Please type '%s' to confirm", who.Username),
+			Validate: func(s string) error {
+				if s != who.Username {
+					return fmt.Errorf("")
+				}
+				return nil
+			},
 		}
 		if _, err := prompt.Run(); err != nil {
 			cmd.End("")
 		}
 
-		ctx, cancel := authCtx(cmdTimeout)
-		defer cancel()
-		if err := hub.DestroyAccount(ctx); err != nil {
+		ctx2, cancel2 := authCtx(cmdTimeout)
+		defer cancel2()
+		if err := hub.DestroyAccount(ctx2); err != nil {
 			cmd.Fatal(err)
 		}
 		_ = os.RemoveAll(authViper.ConfigFileUsed())
-		cmd.Success("Your account and all associated data has been removed")
+		cmd.Success("Your account has been deleted")
 	},
 }

--- a/cmd/tt/keys.go
+++ b/cmd/tt/keys.go
@@ -26,7 +26,7 @@ var keysCmd = &cobra.Command{
 	Short: "Key management",
 	Long:  `Manage your keys.`,
 	Run: func(c *cobra.Command, args []string) {
-		lsKeys()
+		lsKeys(c)
 	},
 }
 
@@ -44,6 +44,14 @@ There are two types of API keys:
 API secrets should be kept safely on a backend server, not in publicly readable client code.
 `,
 	Run: func(c *cobra.Command, args []string) {
+		org, err := c.Flags().GetString("org")
+		if err != nil {
+			cmd.Fatal(err)
+		}
+		if org != "" {
+			configViper.Set("org", org)
+		}
+
 		prompt := promptui.Select{
 			Label: "Select API key type",
 			Items: []string{"account", "user"},
@@ -74,6 +82,14 @@ var invalidateKeysCmd = &cobra.Command{
 	Short: "Invalidate a key",
 	Long:  `Invalidate a key. Invalidated keys cannot be used to create new threads.`,
 	Run: func(c *cobra.Command, args []string) {
+		org, err := c.Flags().GetString("org")
+		if err != nil {
+			cmd.Fatal(err)
+		}
+		if org != "" {
+			configViper.Set("org", org)
+		}
+
 		selected := selectKey("Invalidate key", aurora.Sprintf(
 			aurora.BrightBlack("> Invalidating key {{ .Key | white | bold }}")))
 
@@ -94,11 +110,19 @@ var lsKeysCmd = &cobra.Command{
 	Short: "List your keys",
 	Long:  `List all of your keys.`,
 	Run: func(c *cobra.Command, args []string) {
-		lsKeys()
+		lsKeys(c)
 	},
 }
 
-func lsKeys() {
+func lsKeys(c *cobra.Command) {
+	org, err := c.Flags().GetString("org")
+	if err != nil {
+		cmd.Fatal(err)
+	}
+	if org != "" {
+		configViper.Set("org", org)
+	}
+
 	ctx, cancel := authCtx(cmdTimeout)
 	defer cancel()
 	list, err := hub.ListKeys(ctx)

--- a/cmd/tt/orgs.go
+++ b/cmd/tt/orgs.go
@@ -236,11 +236,11 @@ var destroyOrgsCmd = &cobra.Command{
 	Short: "Destroy an org",
 	Long:  `Destroy an organization and all associated data (interactive). You must be the org owner.`,
 	Run: func(c *cobra.Command, args []string) {
-		selected := selectOrg("Remove org", aurora.Sprintf(
-			aurora.BrightBlack("> Removing org {{ .Name | white | bold }}")))
+		selected := selectOrg("Destroy org", aurora.Sprintf(
+			aurora.BrightBlack("> Destroying org {{ .Name | white | bold }}")))
 		configViper.Set("org", selected.Slug)
 
-		cmd.Message("Are you absolutely sure? This action cannot be undone. The org and all associated data will be permanently deleted.")
+		cmd.Warn("%s", aurora.Red("Are you absolutely sure? This action cannot be undone. The org and all associated data will be permanently deleted."))
 		prompt := promptui.Prompt{
 			Label: fmt.Sprintf("Please type '%s' to confirm", selected.Name),
 			Validate: func(s string) error {

--- a/cmd/tt/threads.go
+++ b/cmd/tt/threads.go
@@ -25,7 +25,7 @@ var threadsCmd = &cobra.Command{
 	Short: "Thread management",
 	Long:  `Manage your threads.`,
 	Run: func(c *cobra.Command, args []string) {
-		lsThreads()
+		lsThreads(c)
 	},
 }
 
@@ -37,11 +37,19 @@ var lsThreadsCmd = &cobra.Command{
 	Short: "List your threads",
 	Long:  `List all of your threads.`,
 	Run: func(c *cobra.Command, args []string) {
-		lsThreads()
+		lsThreads(c)
 	},
 }
 
-func lsThreads() {
+func lsThreads(c *cobra.Command) {
+	org, err := c.Flags().GetString("org")
+	if err != nil {
+		cmd.Fatal(err)
+	}
+	if org != "" {
+		configViper.Set("org", org)
+	}
+
 	ctx, cancel := authCtx(cmdTimeout)
 	defer cancel()
 	list, err := users.ListThreads(ctx)

--- a/cmd/tt/threads.go
+++ b/cmd/tt/threads.go
@@ -105,7 +105,11 @@ func selectThread(label, successMsg string, dbsOnly bool) *threadItem {
 			Type: getThreadType(t.IsDB),
 		})
 	}
-	items = append(items, &threadItem{ID: "Create new", Type: "db"})
+	var name string
+	if len(items) == 0 {
+		name = "default"
+	}
+	items = append(items, &threadItem{ID: "Create new", Name: name, Type: "db"})
 
 	prompt := promptui.Select{
 		Label: label,

--- a/core/core.go
+++ b/core/core.go
@@ -544,7 +544,7 @@ func (t *Textile) threadInterceptor() grpc.UnaryServerInterceptor {
 				return nil, err
 			}
 			if len(keys) != 0 {
-				return nil, status.Error(codes.FailedPrecondition, "DB not empty. Delete buckets first.")
+				return nil, status.Error(codes.FailedPrecondition, "DB not empty (delete buckets first)")
 			}
 		case "/threads.net.pb.API/DeleteThread":
 			deleteID, err = thread.Cast(req.(*netpb.DeleteThreadRequest).ThreadID)


### PR DESCRIPTION
Closes #171 
Closes #179  
Closes #191 

- Improves the UX around choosing a threadDB for a new bucket:
  1. If the account (dev/org) has no DBs, they _are not_ given the option of naming the DB... it will be called "default"
  2. Next time they need to choose a DB, the "default" one is shown on top
  3. If they choose to create a new one, they are then asked what to name it
- Adds `tt bucket destroy`
- Improves UX with _dangerous_ actions like,
  - `tt destroy`: Dev must type their username
  - `tt orgs destroy`: Dev must type the full name of the org
  - `tt bucket destroy`: Dev must confirm
- Fixes `tt threads` and `tt keys` to use the `--org` flag when present (it will still pick up the config setting within a bucket, but the flag will always override)
- Adds a conditional on account deletion: _Owned orgs_ must first be deleted
- An account cleanup fix: Invites from the deleted account were not properly removed