### PR TITLE
ci: dont built for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Compile
         run: |
           export PATH=${PATH}:`go env GOPATH`/bin
-          gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64" -output="hub-{{.OS}}-{{.Arch}}" ./cmd/hub
-          gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64" -output="hub-{{.OS}}-{{.Arch}}" ./cmd/buck
+          gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64" -output="hub-{{.OS}}-{{.Arch}}" ./cmd/hub
+          gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64" -output="hub-{{.OS}}-{{.Arch}}" ./cmd/buck
       - name: Collect artifacts
         run: |
           VERSION=${GITHUB_REF##*/}
@@ -45,7 +45,7 @@ jobs:
           cp README.md tmp/
           cp dist/install tmp/
           cd tmp
-          declare -a arr=("darwin-amd64" "windows-amd64.exe" "linux-amd64" "linux-386" "linux-arm")
+          declare -a arr=("darwin-amd64" "linux-amd64" "linux-386" "linux-arm")
           for i in "${arr[@]}"
           do
               OSARCH=${i%.*}


### PR DESCRIPTION
Temporarily avoid windows build errors related to sector storage.