### PR TITLE
docs: typos and improved cli description

### DIFF
--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -69,7 +69,7 @@ func Init(rootCmd *cobra.Command) {
 	bucketInitCmd.PersistentFlags().Bool("public", false, "Allow public access")
 	bucketInitCmd.PersistentFlags().String("thread", "", "Thread ID")
 	bucketInitCmd.Flags().BoolP("existing", "e", false, "Initializes from an existing remote bucket if true")
-	bucketInitCmd.Flags().String("cid", "", "Bootstrap the bucket with a UnixFS Cid availabe in the IPFS network")
+	bucketInitCmd.Flags().String("cid", "", "Bootstrap the bucket with a UnixFS Cid available in the IPFS network")
 	if err := cmd.BindFlags(config.Viper, bucketInitCmd, config.Flags); err != nil {
 		cmd.Fatal(err)
 	}

--- a/cmd/buck/cli/init.go
+++ b/cmd/buck/cli/init.go
@@ -36,6 +36,7 @@ A .textile config directory and a seed file will be created in the current worki
 Existing configs will not be overwritten.
 
 Use the '--existing' flag to initialize from an existing remote bucket.
+Use the '--cid' flag to initialize from an existing UnixFS DAG.
 `,
 	Args: cobra.ExactArgs(0),
 	PreRun: func(c *cobra.Command, args []string) {


### PR DESCRIPTION
Fixes a typo and improves CLI bucket `init` description.