### PR TITLE
Offline-first bucket watch

### DIFF
--- a/api/buckets/client/client_test.go
+++ b/api/buckets/client/client_test.go
@@ -758,7 +758,7 @@ func setup(t *testing.T) (context.Context, *c.Client) {
 }
 
 func setupWithConf(t *testing.T, conf core.Config) (context.Context, *c.Client) {
-	apitest.MakeTextileWithConfig(t, conf)
+	apitest.MakeTextileWithConfig(t, conf, true)
 	target, err := tutil.TCPAddrFromMultiAddr(conf.AddrAPI)
 	require.Nil(t, err)
 	opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithPerRPCCredentials(common.Credentials{})}

--- a/api/users/client/client_test.go
+++ b/api/users/client/client_test.go
@@ -350,7 +350,7 @@ func setup(t *testing.T) (core.Config, *c.Client, *hc.Client, *tc.Client, *nc.Cl
 }
 
 func setupWithConf(t *testing.T, conf core.Config) (core.Config, *c.Client, *hc.Client, *tc.Client, *nc.Client, *bc.Client) {
-	apitest.MakeTextileWithConfig(t, conf)
+	apitest.MakeTextileWithConfig(t, conf, true)
 	target, err := tutil.TCPAddrFromMultiAddr(conf.AddrAPI)
 	require.Nil(t, err)
 	opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithPerRPCCredentials(common.Credentials{})}

--- a/buckets/local/bucket_test.go
+++ b/buckets/local/bucket_test.go
@@ -365,10 +365,10 @@ func TestBucket_Watch(t *testing.T) {
 	go ec.collect(events)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var wg sync.WaitGroup
 	var onlineStateCount, offlineStateCount int
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 		state := buck1.Watch(ctx, WithWatchEvents(events))
 		for s := range state {

--- a/buckets/local/bucket_test.go
+++ b/buckets/local/bucket_test.go
@@ -370,7 +370,7 @@ func TestBucket_Watch(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		state, err := buck1.Watch(ctx, WithWatchEvents(events))
+		state, err := buck1.Watch(ctx, WithWatchEvents(events), WithOffline(true))
 		require.Nil(t, err)
 		for s := range state {
 			t.Logf("received watch state: %s", s.State)

--- a/buckets/local/bucket_test.go
+++ b/buckets/local/bucket_test.go
@@ -370,7 +370,8 @@ func TestBucket_Watch(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		state := buck1.Watch(ctx, WithWatchEvents(events))
+		state, err := buck1.Watch(ctx, WithWatchEvents(events))
+		require.Nil(t, err)
 		for s := range state {
 			t.Logf("received watch state: %s", s.State)
 			switch s.State {

--- a/buckets/local/buckets_test.go
+++ b/buckets/local/buckets_test.go
@@ -253,7 +253,7 @@ func initCmd(t *testing.T, buckets *Buckets, key string, tid thread.ID, addFlags
 func setup(t *testing.T) *Buckets {
 	conf := apitest.DefaultTextileConfig(t)
 	conf.Hub = false
-	apitest.MakeTextileWithConfig(t, conf)
+	apitest.MakeTextileWithConfig(t, conf, true)
 	target, err := tutil.TCPAddrFromMultiAddr(conf.AddrAPI)
 	require.Nil(t, err)
 	clients := cmd.NewClients(target, false)

--- a/buckets/local/options.go
+++ b/buckets/local/options.go
@@ -126,11 +126,19 @@ func WithAddEvents(ch chan<- PathEvent) AddOption {
 }
 
 type watchOptions struct {
-	events chan<- PathEvent
+	offline bool
+	events  chan<- PathEvent
 }
 
 // WatchOption is used when watching a bucket for changes.
 type WatchOption func(*watchOptions)
+
+// WithOffline will keep watching for bucket changes while the local network is offline.
+func WithOffline(offline bool) WatchOption {
+	return func(args *watchOptions) {
+		args.offline = offline
+	}
+}
 
 // WithWatchEvents allows the caller to receive path events when watching a bucket for changes.
 func WithWatchEvents(ch chan<- PathEvent) WatchOption {

--- a/buckets/local/options.go
+++ b/buckets/local/options.go
@@ -1,8 +1,6 @@
 package local
 
 import (
-	"time"
-
 	cid "github.com/ipfs/go-cid"
 	"github.com/textileio/go-threads/core/thread"
 )
@@ -128,21 +126,11 @@ func WithAddEvents(ch chan<- PathEvent) AddOption {
 }
 
 type watchOptions struct {
-	interval time.Duration
-	events   chan<- PathEvent
+	events chan<- PathEvent
 }
 
 // WatchOption is used when watching a bucket for changes.
 type WatchOption func(*watchOptions)
-
-// WatchInterval sets the interval at which local changes are synced remotely.
-// In other words, this is the interval at which the local file watcher checks
-// for filesystem changes.
-func WithInterval(local time.Duration) WatchOption {
-	return func(args *watchOptions) {
-		args.interval = local
-	}
-}
 
 // WithWatchEvents allows the caller to receive path events when watching a bucket for changes.
 func WithWatchEvents(ch chan<- PathEvent) WatchOption {

--- a/buckets/local/pull.go
+++ b/buckets/local/pull.go
@@ -153,12 +153,6 @@ looop:
 		if err := eg.Wait(); err != nil {
 			return count, err
 		}
-		if events != nil {
-			events <- PathEvent{
-				Path: pth,
-				Type: PathComplete,
-			}
-		}
 	}
 	if len(rm) > 0 {
 		for _, r := range rm {
@@ -175,6 +169,12 @@ looop:
 					Type: FileRemoved,
 				}
 			}
+		}
+	}
+	if events != nil {
+		events <- PathEvent{
+			Path: pth,
+			Type: PathComplete,
 		}
 	}
 	return count, nil

--- a/buckets/local/push.go
+++ b/buckets/local/push.go
@@ -96,12 +96,6 @@ func (b *Bucket) PushLocal(ctx context.Context, opts ...PathOption) (roots Roots
 			rm = append(rm, c)
 		}
 	}
-	if args.events != nil {
-		args.events <- PathEvent{
-			Path: bp,
-			Type: PathComplete,
-		}
-	}
 	if len(rm) > 0 {
 		for _, c := range rm {
 			var err error
@@ -112,6 +106,12 @@ func (b *Bucket) PushLocal(ctx context.Context, opts ...PathOption) (roots Roots
 			if err := b.repo.RemovePath(ctx, c.Name); err != nil {
 				return roots, err
 			}
+		}
+	}
+	if args.events != nil {
+		args.events <- PathEvent{
+			Path: bp,
+			Type: PathComplete,
 		}
 	}
 

--- a/buckets/local/watch.go
+++ b/buckets/local/watch.go
@@ -88,6 +88,10 @@ func (b *Bucket) Watch(ctx context.Context, opts ...WatchOption) <-chan WatchSta
 // and listens for and auto-pulls remote changes as they arrive.
 // This will watch until context is canceled or an error occurs.
 func (b *Bucket) WatchWhileConnected(ctx context.Context, opts ...WatchOption) (<-chan WatchState, error) {
+	ctx, err := b.context(ctx)
+	if err != nil {
+		return nil, err
+	}
 	args := &watchOptions{}
 	for _, opt := range opts {
 		opt(args)

--- a/buckets/local/watch.go
+++ b/buckets/local/watch.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/radovskyb/watcher"
 	"github.com/textileio/go-threads/api/client"
 	"github.com/textileio/textile/buckets"

--- a/buckets/local/watch.go
+++ b/buckets/local/watch.go
@@ -5,92 +5,175 @@ import (
 	"errors"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/radovskyb/watcher"
 	"github.com/textileio/go-threads/api/client"
 	"github.com/textileio/textile/buckets"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-const defaultInterval = time.Millisecond * 100
+const (
+	fileSystemWatchInterval = time.Millisecond * 100
+	reconnectInterval       = time.Second * 5
+)
+
+// WatchState is used to inform Watch callers about the connection state.
+type WatchState struct {
+	// State of the watch connection (online/offline).
+	State ConnectionState
+	// Error returned by the watch operation.
+	Err error
+	// Fatal indicates whether or not the associated error is fatal.
+	// (Connectivity related errors are not fatal.)
+	Fatal bool
+}
+
+// ConnectionState indicates an online/offline state.
+type ConnectionState int
+
+const (
+	// Offline indicates the remote is currently not reachable.
+	Offline ConnectionState = iota
+	// Online indicates a connection with the remote has been established.
+	Online
+)
+
+func (cs ConnectionState) String() string {
+	switch cs {
+	case Online:
+		return "online"
+	case Offline:
+		return "offline"
+	default:
+		return "unknown state"
+	}
+}
 
 // Watch watches for and auto-pushes local bucket changes at an interval,
-// and listens for and auto-pulls remote changes as they arrive
-// This will watch until context is canceled.
-func (b *Bucket) Watch(ctx context.Context, opts ...WatchOption) error {
-	args := &watchOptions{
-		interval: defaultInterval,
-	}
+// and listens for and auto-pulls remote changes as they arrive.
+// This will survive connectivity interruptions.
+// Returns a channel of watch connectivity states. Cancel context to stop watching.
+func (b *Bucket) Watch(ctx context.Context, opts ...WatchOption) <-chan WatchState {
+	bc := backoff.NewConstantBackOff(reconnectInterval)
+	outerState := make(chan WatchState)
+	go func() {
+		defer close(outerState)
+		err := backoff.Retry(func() error {
+			state, err := b.WatchWhileConnected(ctx, opts...)
+			if err != nil {
+				outerState <- WatchState{Err: err, Fatal: true}
+				return nil // Stop retrying
+			}
+			for s := range state {
+				outerState <- s
+				if s.Err != nil {
+					if s.Fatal {
+						return nil // Stop retrying
+					} else {
+						return s.Err // Connection error, keep trying
+					}
+				}
+			}
+			return nil
+		}, bc)
+		if err != nil {
+			outerState <- WatchState{Err: err, Fatal: true}
+		}
+	}()
+	return outerState
+}
+
+// WatchWhileConnected watches for and auto-pushes local bucket changes at an interval,
+// and listens for and auto-pulls remote changes as they arrive.
+// This will watch until context is canceled or an error occurs.
+func (b *Bucket) WatchWhileConnected(ctx context.Context, opts ...WatchOption) (<-chan WatchState, error) {
+	args := &watchOptions{}
 	for _, opt := range opts {
 		opt(args)
 	}
-	errs := make(chan error)
-
-	// Manually sync once on startup
-	if err := b.watchPush(ctx, args.events); err != nil {
-		return err
-	}
-
-	// Start listening for local changes
-	w := watcher.New()
-	defer w.Close()
-	w.SetMaxEvents(1)
-	bp, err := b.Path()
-	if err != nil {
-		return err
-	}
-	if err := w.AddRecursive(bp); err != nil {
-		return err
-	}
-	go func() {
-		if err := w.Start(args.interval); err != nil {
-			errs <- err
-		}
-	}()
-	go func() {
-		for {
-			select {
-			case <-w.Event:
-				if err := b.watchPush(ctx, args.events); err != nil {
-					errs <- err
-				}
-			case err := <-w.Error:
-				errs <- err
-			case <-w.Closed:
-				return
-			}
-		}
-	}()
-
-	// Start listening for remote changes
 	id, err := b.Thread()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	events, err := b.clients.Threads.Listen(ctx, id, []client.ListenOption{{
-		Type:       client.ListenAll,
-		InstanceID: b.Key(),
-	}})
+	bp, err := b.Path()
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	state := make(chan WatchState)
 	go func() {
-		for e := range events {
-			if e.Err != nil {
-				errs <- err // events will close on error
-			} else if err := b.watchPull(ctx, args.events); err != nil {
+		defer close(state)
+		w := watcher.New()
+		defer w.Close()
+		w.SetMaxEvents(1)
+		if err := w.AddRecursive(bp); err != nil {
+			state <- WatchState{Err: err, Fatal: true}
+			return
+		}
+
+		// Start listening for remote changes
+		events, err := b.clients.Threads.Listen(ctx, id, []client.ListenOption{{
+			Type:       client.ListenAll,
+			InstanceID: b.Key(),
+		}})
+		if err != nil {
+			state <- WatchState{Err: err, Fatal: !isConnectionErr(err)}
+			return
+		}
+		errs := make(chan error)
+		go func() {
+			for e := range events {
+				if e.Err != nil {
+					errs <- e.Err // events will close on error
+				} else if err := b.watchPull(ctx, args.events); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}()
+
+		// Start listening for local changes
+		go func() {
+			if err := w.Start(fileSystemWatchInterval); err != nil {
 				errs <- err
+			}
+		}()
+		go func() {
+			for {
+				select {
+				case <-w.Event:
+					if err := b.watchPush(ctx, args.events); err != nil {
+						errs <- err
+					}
+				case err := <-w.Error:
+					errs <- err
+				case <-w.Closed:
+					return
+				}
+			}
+		}()
+
+		// If we made it here, we must be online
+		state <- WatchState{State: Online}
+
+		// Manually sync once on startup
+		if err := b.watchPush(ctx, args.events); err != nil {
+			state <- WatchState{Err: err, Fatal: !isConnectionErr(err)}
+			return
+		}
+
+		for {
+			select {
+			case err := <-errs:
+				state <- WatchState{Err: err, Fatal: !isConnectionErr(err)}
+				return
+			case <-ctx.Done():
 				return
 			}
 		}
 	}()
-
-	for {
-		select {
-		case err := <-errs:
-			return err
-		case <-ctx.Done():
-			return nil
-		}
-	}
+	return state, nil
 }
 
 func (b *Bucket) watchPush(ctx context.Context, events chan<- PathEvent) error {
@@ -129,4 +212,8 @@ func (b *Bucket) watchPull(ctx context.Context, events chan<- PathEvent) error {
 		// Ignore if there's a push in progress
 	}
 	return nil
+}
+
+func isConnectionErr(err error) bool {
+	return status.Code(err) == codes.Unavailable
 }

--- a/cmd/buck/cli/add.go
+++ b/cmd/buck/cli/add.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/buckets/local"
 	"github.com/textileio/textile/cmd"
+	"github.com/textileio/uiprogress"
 )
 
 var addCmd = &cobra.Command{
@@ -26,13 +27,16 @@ var addCmd = &cobra.Command{
 		cmd.ErrCheck(err)
 		events := make(chan local.PathEvent)
 		defer close(events)
-		go handleProgressBars(events, false)
+		progress := uiprogress.New()
+		progress.Start()
+		go handleProgressBars(progress, events)
 		err = buck.AddRemoteCid(
 			ctx,
 			target,
 			args[1],
 			local.WithSelectMerge(getSelectMergeStrategy(yes)),
 			local.WithAddEvents(events))
+		progress.Stop()
 		cmd.ErrCheck(err)
 		cmd.Success("Merged %s with %s", target, args[1])
 	},

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
@@ -45,8 +44,6 @@ func Init(baseCmd *cobra.Command) {
 	pullCmd.Flags().BoolP("yes", "y", false, "Skips the confirmation prompt if true")
 
 	addCmd.Flags().BoolP("yes", "y", false, "Skips confirmations prompts to always overwrite files and merge folders")
-
-	watchCmd.Flags().Duration("interval", time.Millisecond*100, "The interval at which local changes are synced remotely")
 
 	encryptCmd.Flags().StringP("password", "p", "", "Encryption password")
 	decryptCmd.Flags().StringP("password", "p", "", "Decryption password")

--- a/cmd/buck/cli/pull.go
+++ b/cmd/buck/cli/pull.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/buckets/local"
 	"github.com/textileio/textile/cmd"
+	"github.com/textileio/uiprogress"
 )
 
 var pullCmd = &cobra.Command{
@@ -28,13 +29,16 @@ var pullCmd = &cobra.Command{
 		cmd.ErrCheck(err)
 		events := make(chan local.PathEvent)
 		defer close(events)
-		go handleProgressBars(events, false)
+		progress := uiprogress.New()
+		progress.Start()
+		go handleProgressBars(progress, events)
 		roots, err := buck.PullRemote(
 			ctx,
 			local.WithConfirm(getConfirm("Discard %d local changes", yes)),
 			local.WithForce(force),
 			local.WithHard(hard),
 			local.WithPathEvents(events))
+		progress.Stop()
 		if errors.Is(err, local.ErrAborted) {
 			cmd.End("")
 		} else if errors.Is(err, local.ErrUpToDate) {

--- a/cmd/buck/cli/push.go
+++ b/cmd/buck/cli/push.go
@@ -10,6 +10,7 @@ import (
 	"github.com/textileio/textile/buckets"
 	"github.com/textileio/textile/buckets/local"
 	"github.com/textileio/textile/cmd"
+	"github.com/textileio/uiprogress"
 )
 
 var (
@@ -47,12 +48,15 @@ var pushCmd = &cobra.Command{
 
 		events := make(chan local.PathEvent)
 		defer close(events)
-		go handleProgressBars(events, false)
+		progress := uiprogress.New()
+		progress.Start()
+		go handleProgressBars(progress, events)
 		roots, err := buck.PushLocal(
 			ctx,
 			local.WithConfirm(getConfirm("Push %d changes", yes)),
 			local.WithForce(force),
 			local.WithPathEvents(events))
+		progress.Stop()
 		if errors.Is(err, local.ErrAborted) {
 			cmd.End("")
 		} else if errors.Is(err, local.ErrUpToDate) {

--- a/cmd/buck/cli/util.go
+++ b/cmd/buck/cli/util.go
@@ -37,9 +37,7 @@ func handleProgressBars(p *uiprogress.Progress, events chan local.PathEvent) {
 	for e := range events {
 		switch e.Type {
 		case local.FileStart:
-			if p != nil {
-				bars[e.Path] = addBar(p, e.Path, e.Size)
-			}
+			bars[e.Path] = addBar(p, e.Path, e.Size)
 		case local.FileProgress, local.FileComplete:
 			bar, ok := bars[e.Path]
 			if ok {
@@ -50,10 +48,8 @@ func handleProgressBars(p *uiprogress.Progress, events chan local.PathEvent) {
 				}
 			}
 		case local.FileRemoved:
-			if p != nil {
-				bar := p.AddBar(int(e.Size))
-				finishBar(p, bar, e.Path, e.Cid, true)
-			}
+			bar := p.AddBar(int(e.Size))
+			finishBar(p, bar, e.Path, e.Cid, true)
 		}
 	}
 }
@@ -68,6 +64,12 @@ func addBar(p *uiprogress.Progress, pth string, size int64) *uiprogress.Bar {
 		return pre + "  " + c + " / " + total
 	})
 	return bar
+}
+
+func addInfoBar(p *uiprogress.Progress, msg string) {
+	bar := p.AddBar(0)
+	bar.Final = msg
+	p.Print()
 }
 
 func finishBar(p *uiprogress.Progress, bar *uiprogress.Bar, pth string, c cid.Cid, removal bool) {

--- a/cmd/buck/cli/util.go
+++ b/cmd/buck/cli/util.go
@@ -66,12 +66,6 @@ func addBar(p *uiprogress.Progress, pth string, size int64) *uiprogress.Bar {
 	return bar
 }
 
-func addInfoBar(p *uiprogress.Progress, msg string) {
-	bar := p.AddBar(0)
-	bar.Final = msg
-	p.Print()
-}
-
 func finishBar(p *uiprogress.Progress, bar *uiprogress.Bar, pth string, c cid.Cid, removal bool) {
 	if removal {
 		bar.Final = "- " + pth

--- a/cmd/buck/cli/watch.go
+++ b/cmd/buck/cli/watch.go
@@ -27,7 +27,8 @@ var watchCmd = &cobra.Command{
 		progress := uiprogress.New()
 		progress.Start()
 		go handleProgressBars(progress, events)
-		state := buck.Watch(ctx, local.WithWatchEvents(events))
+		state, err := buck.Watch(ctx, local.WithWatchEvents(events), local.WithOffline(true))
+		cmd.ErrCheck(err)
 		for s := range state {
 			switch s.State {
 			case local.Online:
@@ -41,6 +42,5 @@ var watchCmd = &cobra.Command{
 			}
 		}
 		progress.Stop()
-		cmd.ErrCheck(err)
 	},
 }

--- a/cmd/buck/cli/watch.go
+++ b/cmd/buck/cli/watch.go
@@ -2,8 +2,8 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/buckets/local"
 	"github.com/textileio/textile/cmd"
@@ -31,23 +31,16 @@ var watchCmd = &cobra.Command{
 		for s := range state {
 			switch s.State {
 			case local.Online:
-				cmd.Success("Watching %s for changes...", aurora.White(bp).Bold())
-				if progress == nil {
-					progress = uiprogress.New()
-				}
-				progress.Start()
+				addInfoBar(progress, fmt.Sprintf("> Connected! Watching %s for changes...", bp))
 			case local.Offline:
-				if progress != nil {
-					progress.Stop()
-					progress = nil
-				}
 				if s.Fatal {
 					cmd.Fatal(s.Err)
 				} else {
-					cmd.Message("Not connected. Trying to connect...")
+					addInfoBar(progress, "> Not connected. Trying to connect...")
 				}
 			}
 		}
+		progress.Stop()
 		cmd.ErrCheck(err)
 	},
 }

--- a/cmd/buck/cli/watch.go
+++ b/cmd/buck/cli/watch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/logrusorgru/aurora"
-
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/buckets/local"
 	"github.com/textileio/textile/cmd"
@@ -48,7 +47,7 @@ func handleWatchEvents(events chan local.PathEvent) {
 		case local.FileComplete:
 			cmd.Message("%s: %s (%s)", aurora.Green("+ "+e.Path), e.Cid, formatBytes(e.Size, true))
 		case local.FileRemoved:
-			cmd.Message("%s", aurora.Red("- "+e.Path).Bold())
+			cmd.Message("%s", aurora.Red("- "+e.Path))
 		}
 	}
 }

--- a/cmd/buck/cli/watch.go
+++ b/cmd/buck/cli/watch.go
@@ -2,12 +2,12 @@ package cli
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/logrusorgru/aurora"
 
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/buckets/local"
 	"github.com/textileio/textile/cmd"
-	"github.com/textileio/uiprogress"
 )
 
 var watchCmd = &cobra.Command{
@@ -24,23 +24,31 @@ var watchCmd = &cobra.Command{
 		cmd.ErrCheck(err)
 		events := make(chan local.PathEvent)
 		defer close(events)
-		progress := uiprogress.New()
-		progress.Start()
-		go handleProgressBars(progress, events)
+		go handleWatchEvents(events)
 		state, err := buck.Watch(ctx, local.WithWatchEvents(events), local.WithOffline(true))
 		cmd.ErrCheck(err)
 		for s := range state {
 			switch s.State {
 			case local.Online:
-				addInfoBar(progress, fmt.Sprintf("> Connected! Watching %s for changes...", bp))
+				cmd.Success("Watching %s for changes...", aurora.White(bp).Bold())
 			case local.Offline:
 				if s.Fatal {
 					cmd.Fatal(s.Err)
 				} else {
-					addInfoBar(progress, "> Not connected. Trying to connect...")
+					cmd.Message("Not connected. Trying to connect...")
 				}
 			}
 		}
-		progress.Stop()
 	},
+}
+
+func handleWatchEvents(events chan local.PathEvent) {
+	for e := range events {
+		switch e.Type {
+		case local.FileComplete:
+			cmd.Message("%s: %s (%s)", aurora.Green("+ "+e.Path), e.Cid, formatBytes(e.Size, true))
+		case local.FileRemoved:
+			cmd.Message("%s", aurora.Red("- "+e.Path).Bold())
+		}
+	}
 }

--- a/cmd/buckd/main.go
+++ b/cmd/buckd/main.go
@@ -245,7 +245,7 @@ var rootCmd = &cobra.Command{
 			Debug: config.Viper.GetBool("log.debug"),
 		})
 		cmd.ErrCheck(err)
-		defer textile.Close()
+		defer textile.Close(false)
 		textile.Bootstrap()
 
 		fmt.Println("Welcome to Buckets!")

--- a/cmd/hubd/main.go
+++ b/cmd/hubd/main.go
@@ -338,7 +338,7 @@ var rootCmd = &cobra.Command{
 			Debug: config.Viper.GetBool("log.debug"),
 		})
 		cmd.ErrCheck(err)
-		defer textile.Close()
+		defer textile.Close(false)
 		textile.Bootstrap()
 
 		fmt.Println("Welcome to the Hub!")

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -21,7 +21,8 @@ func Warn(format string, args ...interface{}) {
 	if format == "" {
 		return
 	}
-	fmt.Println(aurora.Sprintf(aurora.Yellow("! "+format), args...))
+	fmt.Println(aurora.Sprintf(aurora.Yellow("> Warning! %s"),
+		aurora.Sprintf(aurora.BrightBlack(format), args...)))
 }
 
 func Success(format string, args ...interface{}) {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/alecthomas/jsonschema v0.0.0-20191017121752-4bb6e3fae4f2
 	github.com/caarlos0/spin v1.1.0
-	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.0.2
 	github.com/cloudflare/cloudflare-go v0.11.6
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/alecthomas/jsonschema v0.0.0-20191017121752-4bb6e3fae4f2
 	github.com/caarlos0/spin v1.1.0
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cloudflare/cloudflare-go v0.11.6
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
@@ -62,7 +63,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/textileio/dcrypto v0.0.1
 	github.com/textileio/go-assets v0.0.0-20200430191519-b341e634e2b7
-	github.com/textileio/go-threads v0.1.23
+	github.com/textileio/go-threads v0.1.24-0.20200717194205-b42e93961722
 	github.com/textileio/powergate v0.0.1-beta.13.0.20200703203605-db27e80fa8b5
 	github.com/textileio/uiprogress v0.0.4
 	go.mongodb.org/mongo-driver v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 // indirect
 	github.com/alecthomas/jsonschema v0.0.0-20191017121752-4bb6e3fae4f2
 	github.com/caarlos0/spin v1.1.0
-	github.com/cenkalti/backoff/v4 v4.0.2
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cloudflare/cloudflare-go v0.11.6
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,6 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
-github.com/cenkalti/backoff/v4 v4.0.2 h1:JIufpQLbh4DkbQoii76ItQIUFzevQSqOLZca4eamEDs=
-github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/cenkalti/backoff/v4 v4.0.2 h1:JIufpQLbh4DkbQoii76ItQIUFzevQSqOLZca4eamEDs=
+github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/go.sum
+++ b/go.sum
@@ -1518,8 +1518,8 @@ github.com/textileio/dcrypto v0.0.1 h1:ftXQKd+CAM7a0XFrw+hJqizo+ux8+g5RttKjImZRc
 github.com/textileio/dcrypto v0.0.1/go.mod h1:rDlYXuL+HQwkyrxOR230zEUouRnlTwH6O5XWoPbmfcE=
 github.com/textileio/go-assets v0.0.0-20200430191519-b341e634e2b7 h1:J7+UXJT/Ku8ylMqqHH4T+CiHtOSd8woUZjynG3fEwDI=
 github.com/textileio/go-assets v0.0.0-20200430191519-b341e634e2b7/go.mod h1:j7aKMh8sbbtvttp7V7yCOkHW/pfRtIM/6h+8qEDsLyI=
-github.com/textileio/go-threads v0.1.23 h1:vhFd1DkJ/17lDNuFP2jc2kRje8XOtdAKFjNM/v/qhuc=
-github.com/textileio/go-threads v0.1.23/go.mod h1:64L0Vgmhs/+J92OdIblMaNC8rsaiWEtHotAikgkychw=
+github.com/textileio/go-threads v0.1.24-0.20200717194205-b42e93961722 h1:QLXNezkSqka09JQ7KMj2D52YQOBBhdqF4DH2ECSM86U=
+github.com/textileio/go-threads v0.1.24-0.20200717194205-b42e93961722/go.mod h1:64L0Vgmhs/+J92OdIblMaNC8rsaiWEtHotAikgkychw=
 github.com/textileio/powergate v0.0.1-beta.13.0.20200703203605-db27e80fa8b5 h1:sZxhbihpeGscOsceiLw7uokXQK0EoSmykAm+EpwgVSs=
 github.com/textileio/powergate v0.0.1-beta.13.0.20200703203605-db27e80fa8b5/go.mod h1:D3ImIiFCJSFdNdSO1m1SL+P8kQvW2Jrkc6hAZI8h7Bg=
 github.com/textileio/uiprogress v0.0.4 h1:7FWXEKK/h54ssNOW24q9MeJ9Eujptsr8eDPq35aPHjo=

--- a/integrationtest/pg/pg_test.go
+++ b/integrationtest/pg/pg_test.go
@@ -204,7 +204,7 @@ func setup(t *testing.T) (context.Context, *c.Client) {
 			},
 		},
 	}
-	apitest.MakeTextileWithConfig(t, conf)
+	apitest.MakeTextileWithConfig(t, conf, true)
 	target, err := tutil.TCPAddrFromMultiAddr(conf.AddrAPI)
 	require.Nil(t, err)
 	opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithPerRPCCredentials(common.Credentials{})}


### PR DESCRIPTION
Closes #275 

This is the missing piece of the _offline-first_ bucket sync w/ diffing functionality. From the `Watch` docstring: 

```
// Watch watches for and auto-pushes local bucket changes at an interval,
// and listens for and auto-pulls remote changes as they arrive.
// This will survive connectivity interruptions.
// Returns a channel of watch connectivity states. Cancel context to stop watching.
```

Demo: https://bafk7wyub5byqrryei4wbb7smmwqhiiuyhikyxu36o5rq4vixnwkwhia.thread.hub.textile.io/buckets/bafzbeib5zrflczb5scupkw2xd3277yxxycpdsre2uiwzzth3s2t2duljbm/watch_offline.mp4