### PR TITLE
pg: archive tracker component

### DIFF
--- a/api/buckets/service.go
+++ b/api/buckets/service.go
@@ -780,14 +780,14 @@ func (s *Service) getNodeAtPath(ctx context.Context, pth path.Resolved, key []by
 
 // decryptNode returns a decrypted version of node.
 func decryptNode(cn ipld.Node, key []byte) (ipld.Node, error) {
-	switch cn.(type) {
+	switch cn := cn.(type) {
 	case *dag.RawNode:
 		return cn, nil // All raw nodes will be leaves
 	case *dag.ProtoNode:
 		if key == nil {
 			return cn, nil
 		}
-		fn, err := unixfs.FSNodeFromBytes(cn.(*dag.ProtoNode).Data())
+		fn, err := unixfs.FSNodeFromBytes(cn.Data())
 		if err != nil {
 			return nil, err
 		}

--- a/buckets/archive/tracker.go
+++ b/buckets/archive/tracker.go
@@ -149,9 +149,7 @@ func (t *Tracker) trackArchiveProgress(ctx context.Context, buckKey string, dbID
 		return true, "watching cancelled", nil
 	case s, ok := <-ch:
 		if !ok {
-			log.Errorf("getting job %s status stream closed", jid)
-			aborted = true
-			abortMsg = "server closed communication channel"
+			return true, "powergate closed communication chan", nil
 		}
 		if s.Err != nil {
 			log.Errorf("job %s update: %s", jid, s.Err)
@@ -176,7 +174,12 @@ func (t *Tracker) trackArchiveProgress(ctx context.Context, buckKey string, dbID
 		return true, fmt.Sprintf("updating archive status: %s", err), nil
 	}
 
-	return false, "reached final status", nil
+	msg := "reached final status"
+	if aborted {
+		msg = "aborted with reason " + abortMsg
+	}
+
+	return false, msg, nil
 }
 
 // updateArchiveStatus save the last known job status. It also receives an

--- a/buckets/archive/tracker.go
+++ b/buckets/archive/tracker.go
@@ -1,0 +1,263 @@
+package archive
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	logger "github.com/ipfs/go-log"
+	"github.com/textileio/go-threads/core/thread"
+	powc "github.com/textileio/powergate/api/client"
+	"github.com/textileio/powergate/ffs"
+	"github.com/textileio/textile/api/common"
+	mdb "github.com/textileio/textile/mongodb"
+	tdb "github.com/textileio/textile/threaddb"
+)
+
+const (
+	maxConcurrent = 20
+)
+
+var (
+	CheckInterval         = time.Second * 15
+	JobStatusPollInterval = time.Second * 30
+
+	log = logger.Logger("pow-archive")
+)
+
+type Tracker struct {
+	lock   sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+	closed chan (struct{})
+
+	internalSession string
+	colls           *mdb.Collections
+	buckets         *tdb.Buckets
+	pgClient        *powc.Client
+}
+
+func New(colls *mdb.Collections, buckets *tdb.Buckets, pgClient *powc.Client, internalSession string) (*Tracker, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t := &Tracker{
+		ctx:    ctx,
+		cancel: cancel,
+		closed: make(chan struct{}),
+
+		internalSession: internalSession,
+		colls:           colls,
+		buckets:         buckets,
+		pgClient:        pgClient,
+	}
+	go t.run()
+	return t, nil
+}
+
+func (t *Tracker) Close() error {
+	t.cancel()
+	<-t.closed
+	return nil
+}
+
+func (t *Tracker) run() {
+	defer close(t.closed)
+	for {
+		select {
+		case <-t.ctx.Done():
+			log.Info("shutting down archive tracker daemon")
+			return
+		case <-time.After(CheckInterval):
+			for {
+				archives, err := t.colls.ArchiveTracking.GetReadyToCheck(t.ctx, maxConcurrent)
+				if err != nil {
+					log.Errorf("getting tracked archives: %s", err)
+					break
+				}
+				log.Infof("get %d ready archive tracking to be processed", len(archives))
+				if len(archives) == 0 {
+					break
+				}
+				var wg sync.WaitGroup
+				wg.Add(len(archives))
+				for _, a := range archives {
+					go func(a *mdb.TrackedArchive) {
+						defer wg.Done()
+
+						ctx, cancel := context.WithTimeout(t.ctx, time.Second*5)
+						defer cancel()
+						reschedule, cause, err := t.trackArchiveProgress(ctx, a.BucketKey, a.DbID, a.DbToken, a.JID, a.BucketRoot)
+						if err != nil || !reschedule {
+							if err != nil {
+								cause = err.Error()
+							}
+							log.Infof("tracking archive finalized with cause: %s", cause)
+							if err := t.colls.ArchiveTracking.Finalize(ctx, a.JID, cause); err != nil {
+								log.Errorf("finalizing errored/rescheduled archive tracking: %s", err)
+							}
+							return
+						}
+						log.Infof("rescheduling tracking archive with job %s, cause %s", a.JID, cause)
+						if err := t.colls.ArchiveTracking.Reschedule(ctx, a.JID, JobStatusPollInterval); err != nil {
+							log.Errorf("rescheduling tracked archive: %s", err)
+						}
+
+					}(a)
+				}
+				wg.Wait()
+			}
+
+		}
+	}
+}
+
+func (t *Tracker) Track(ctx context.Context, dbID thread.ID, dbToken thread.Token, bucketKey string, jid ffs.JobID, bucketRoot cid.Cid) error {
+	if err := t.colls.ArchiveTracking.Create(ctx, dbID, dbToken, bucketKey, jid, bucketRoot); err != nil {
+		return fmt.Errorf("saving tracking information: %s", err)
+	}
+	return nil
+}
+
+// trackArcvhiveProgress queries the current archive status.
+// If a fatal error in tracking happens, it will return an error, which indicates the archive should be untracked.
+// If the archive didn't reach a final status yet, or a possibly recoverable error (by retrying) happens, it will return (true, "retry cause", nil).
+// If the archive reach final status, it will return (false, "", nil) and the tracking can be considered done.
+func (t *Tracker) trackArchiveProgress(ctx context.Context, buckKey string, dbID thread.ID, dbToken thread.Token, jid ffs.JobID, bucketRoot cid.Cid) (bool, string, error) {
+	log.Infof("querying archive status of job %s", jid)
+	defer log.Infof("finished querying archive status of job %s", jid)
+	ffsi, err := t.colls.FFSInstances.Get(ctx, buckKey)
+	if err != nil {
+		return true, fmt.Sprintf("getting instance data: %s", err), nil
+	}
+	// Step 1: watch for the Job status, and keep updating on Mongo until
+	// we're in a final state.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	ctx = context.WithValue(ctx, powc.AuthKey, ffsi.FFSToken)
+	ch := make(chan powc.JobEvent, 1)
+	if err := t.pgClient.FFS.WatchJobs(ctx, ch, jid); err != nil {
+		return true, fmt.Sprintf("watching current job %s for bucket %s: %s", jid, buckKey, err), nil
+	}
+
+	var aborted bool
+	var abortMsg string
+	var job ffs.Job
+	select {
+	case <-ctx.Done():
+		log.Infof("job %s status watching canceled", jid)
+		return true, "watching cancelled", nil
+	case s, ok := <-ch:
+		if !ok {
+			log.Errorf("getting job %s status stream closed", jid)
+			aborted = true
+			abortMsg = "server closed communication channel"
+		}
+		if s.Err != nil {
+			log.Errorf("job %s update: %s", jid, s.Err)
+			aborted = true
+			abortMsg = s.Err.Error()
+		}
+		job = s.Job
+	}
+
+	if !isJobStatusFinal(job.Status) {
+		return true, "no final status yet", nil
+	}
+
+	// Step 2: On success, save Deal data in the underlying Bucket thread. On
+	// failure save the error message. Also update status on Mongo for the archive.
+	if job.Status == ffs.Success {
+		if err := t.saveDealsInArchive(ctx, buckKey, dbID, dbToken, ffsi.FFSToken, bucketRoot); err != nil {
+			return true, fmt.Sprintf("saving deal data in archive: %s", err), nil
+		}
+	}
+	if err := t.updateArchiveStatus(ctx, ffsi, job, aborted, abortMsg); err != nil {
+		return true, fmt.Sprintf("updating archive status: %s", err), nil
+	}
+
+	return false, "reached final status", nil
+}
+
+// updateArchiveStatus save the last known job status. It also receives an
+// _abort_ flag which indicates that the provided newJobStatus might not be
+// final. For example, if tracking the Job status changes errored by some network
+// condition, we have only the last known Job status. Powergate would continue doing
+// its work until a final status is reached; it only means we aren't sure how this
+// archive really finished.
+// To track for this situation, we use the _aborted_ and _abortMsg_ parameters.
+// An archive with _aborted_ true should eventually be re-queried to understand
+// how it finished (if wanted).
+func (t *Tracker) updateArchiveStatus(ctx context.Context, ffsi *mdb.FFSInstance, job ffs.Job, aborted bool, abortMsg string) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	lastArchive := &ffsi.Archives.Current
+	if lastArchive.JobID != job.ID.String() {
+		for i := range ffsi.Archives.History {
+			if ffsi.Archives.History[i].JobID == job.ID.String() {
+				lastArchive = &ffsi.Archives.History[i]
+				break
+			}
+		}
+	}
+	lastArchive.JobStatus = int(job.Status)
+	lastArchive.Aborted = aborted
+	lastArchive.AbortedMsg = abortMsg
+	lastArchive.FailureMsg = prepareFailureMsg(job)
+	if err := t.colls.FFSInstances.Replace(ctx, ffsi); err != nil {
+		return fmt.Errorf("updating ffs status update instance data: %s", err)
+	}
+	return nil
+}
+
+func (t *Tracker) saveDealsInArchive(ctx context.Context, key string, dbID thread.ID, dbToken thread.Token, ffsToken string, c cid.Cid) error {
+	opts := tdb.WithToken(dbToken)
+	ctx = common.NewSessionContext(ctx, t.internalSession)
+	buck := &tdb.Bucket{}
+	if err := t.buckets.Get(ctx, dbID, key, &buck, opts); err != nil {
+		return fmt.Errorf("getting bucket for save deals: %s", err)
+	}
+	ctxFFS := context.WithValue(ctx, powc.AuthKey, ffsToken)
+	sh, err := t.pgClient.FFS.Show(ctxFFS, c)
+	if err != nil {
+		return fmt.Errorf("getting cid info: %s", err)
+	}
+
+	proposals := sh.GetCidInfo().GetCold().GetFilecoin().GetProposals()
+
+	deals := make([]tdb.Deal, len(proposals))
+	for i, p := range proposals {
+		deals[i] = tdb.Deal{
+			ProposalCid: p.GetProposalCid(),
+			Miner:       p.GetMiner(),
+		}
+	}
+	buck.Archives.Current = tdb.Archive{
+		Cid:   c.String(),
+		Deals: deals,
+	}
+	buck.UpdatedAt = time.Now().UnixNano()
+	if err = t.buckets.SaveSafe(ctx, dbID, buck, opts); err != nil {
+		return fmt.Errorf("saving deals in thread: %s", err)
+	}
+	return nil
+}
+
+func prepareFailureMsg(job ffs.Job) string {
+	if job.ErrCause == "" {
+		return ""
+	}
+	var b strings.Builder
+	_, _ = b.WriteString(job.ErrCause)
+	for i, de := range job.DealErrors {
+		_, _ = b.WriteString(fmt.Sprintf("\nDeal error %d: Proposal %s with miner %s, %s", i, de.ProposalCid, de.Miner, de.Message))
+	}
+	return b.String()
+}
+
+func isJobStatusFinal(js ffs.JobStatus) bool {
+	return js == ffs.Success ||
+		js == ffs.Canceled ||
+		js == ffs.Failed
+}

--- a/buckets/archive/tracker.go
+++ b/buckets/archive/tracker.go
@@ -100,10 +100,9 @@ func (t *Tracker) run() {
 							return
 						}
 						log.Infof("rescheduling tracking archive with job %s, cause %s", a.JID, cause)
-						if err := t.colls.ArchiveTracking.Reschedule(ctx, a.JID, JobStatusPollInterval); err != nil {
+						if err := t.colls.ArchiveTracking.Reschedule(ctx, a.JID, JobStatusPollInterval, cause); err != nil {
 							log.Errorf("rescheduling tracked archive: %s", err)
 						}
-
 					}(a)
 				}
 				wg.Wait()

--- a/buckets/archive/tracker.go
+++ b/buckets/archive/tracker.go
@@ -119,7 +119,7 @@ func (t *Tracker) Track(ctx context.Context, dbID thread.ID, dbToken thread.Toke
 	return nil
 }
 
-// trackArcvhiveProgress queries the current archive status.
+// trackArchiveProgress queries the current archive status.
 // If a fatal error in tracking happens, it will return an error, which indicates the archive should be untracked.
 // If the archive didn't reach a final status yet, or a possibly recoverable error (by retrying) happens, it will return (true, "retry cause", nil).
 // If the archive reach final status, it will return (false, "", nil) and the tracking can be considered done.

--- a/buckets/local/buckets_test.go
+++ b/buckets/local/buckets_test.go
@@ -325,7 +325,6 @@ func (c *eventCollector) collect(events chan PathEvent) {
 		}
 		c.Unlock()
 	}
-	return
 }
 
 func (c *eventCollector) check(t *testing.T, numFilesAdded, numFilesRemoved int) {

--- a/buckets/local/options.go
+++ b/buckets/local/options.go
@@ -2,14 +2,14 @@ package local
 
 import (
 	cid "github.com/ipfs/go-cid"
-	"github.com/textileio/go-threads/core/thread"
 )
 
 type newOptions struct {
 	name    string
 	private bool
-	thread  thread.ID
-	key     string
+	// (jsign): unused?
+	//thread  thread.ID
+	//key     string
 	fromCid cid.Cid
 	events  chan<- PathEvent
 }

--- a/buckets/local/options.go
+++ b/buckets/local/options.go
@@ -7,9 +7,6 @@ import (
 type newOptions struct {
 	name    string
 	private bool
-	// (jsign): unused?
-	//thread  thread.ID
-	//key     string
 	fromCid cid.Cid
 	events  chan<- PathEvent
 }

--- a/core/core.go
+++ b/core/core.go
@@ -260,9 +260,11 @@ func NewTextile(ctx context.Context, conf Config) (*Textile, error) {
 			Mail:        t.mail,
 		}
 	}
-	t.archiveTracker, err = archive.New(t.collections, t.bucks, t.powc, t.internalHubSession)
-	if err != nil {
-		return nil, err
+	if conf.Hub {
+		t.archiveTracker, err = archive.New(t.collections, t.bucks, t.powc, t.internalHubSession)
+		if err != nil {
+			return nil, err
+		}
 	}
 	bs := &buckets.Service{
 		Collections:               t.collections,
@@ -387,8 +389,10 @@ func (t *Textile) Close(force bool) error {
 	} else {
 		t.server.GracefulStop()
 	}
-	if err := t.archiveTracker.Close(); err != nil {
-		return err
+	if t.archiveTracker != nil {
+		if err := t.archiveTracker.Close(); err != nil {
+			return err
+		}
 	}
 	if err := t.bucks.Close(); err != nil {
 		return err

--- a/core/core.go
+++ b/core/core.go
@@ -36,6 +36,7 @@ import (
 	hpb "github.com/textileio/textile/api/hub/pb"
 	"github.com/textileio/textile/api/users"
 	upb "github.com/textileio/textile/api/users/pb"
+	"github.com/textileio/textile/buckets/archive"
 	"github.com/textileio/textile/dns"
 	"github.com/textileio/textile/email"
 	"github.com/textileio/textile/gateway"
@@ -75,12 +76,13 @@ var (
 type Textile struct {
 	collections *mdb.Collections
 
-	ts    tc.NetBoostrapper
-	th    *threads.Client
-	thn   *netclient.Client
-	bucks *tdb.Buckets
-	mail  *tdb.Mail
-	powc  *powc.Client
+	ts             tc.NetBoostrapper
+	th             *threads.Client
+	thn            *netclient.Client
+	bucks          *tdb.Buckets
+	mail           *tdb.Mail
+	powc           *powc.Client
+	archiveTracker *archive.Tracker
 
 	ipnsm *ipns.Manager
 	dnsm  *dns.Manager
@@ -88,9 +90,9 @@ type Textile struct {
 	server *grpc.Server
 	proxy  *http.Server
 
-	gateway         *gateway.Gateway
-	gatewaySession  string
-	emailSessionBus *broadcast.Broadcaster
+	gateway            *gateway.Gateway
+	internalHubSession string
+	emailSessionBus    *broadcast.Broadcaster
 
 	conf Config
 }
@@ -137,17 +139,19 @@ type Config struct {
 func NewTextile(ctx context.Context, conf Config) (*Textile, error) {
 	if conf.Debug {
 		if err := tutil.SetLogLevels(map[string]logging.LogLevel{
-			"core":       logging.LevelDebug,
-			"threaddb":   logging.LevelDebug,
-			"hubapi":     logging.LevelDebug,
-			"bucketsapi": logging.LevelDebug,
-			"usersapi":   logging.LevelDebug,
+			"core":        logging.LevelDebug,
+			"threaddb":    logging.LevelDebug,
+			"hubapi":      logging.LevelDebug,
+			"bucketsapi":  logging.LevelDebug,
+			"usersapi":    logging.LevelDebug,
+			"pow-archive": logging.LevelDebug,
 		}); err != nil {
 			return nil, err
 		}
 	}
 	t := &Textile{
-		conf: conf,
+		conf:               conf,
+		internalHubSession: util.MakeToken(32),
 	}
 
 	// Configure clients
@@ -256,6 +260,10 @@ func NewTextile(ctx context.Context, conf Config) (*Textile, error) {
 			Mail:        t.mail,
 		}
 	}
+	t.archiveTracker, err = archive.New(t.collections, t.bucks, t.powc, t.internalHubSession)
+	if err != nil {
+		return nil, err
+	}
 	bs := &buckets.Service{
 		Collections:               t.collections,
 		Buckets:                   t.bucks,
@@ -266,6 +274,8 @@ func NewTextile(ctx context.Context, conf Config) (*Textile, error) {
 		IPFSClient:                ic,
 		IPNSManager:               t.ipnsm,
 		DNSManager:                t.dnsm,
+		PGClient:                  t.powc,
+		ArchiveTracker:            t.archiveTracker,
 	}
 
 	// Start serving
@@ -333,14 +343,13 @@ func NewTextile(ctx context.Context, conf Config) (*Textile, error) {
 	}()
 
 	// Configure gateway
-	t.gatewaySession = util.MakeToken(32)
 	t.gateway, err = gateway.NewGateway(gateway.Config{
 		Addr:            conf.AddrGatewayHost,
 		URL:             conf.AddrGatewayURL,
 		Subdomains:      conf.UseSubdomains,
 		BucketsDomain:   conf.DNSDomain,
 		APIAddr:         conf.AddrAPI,
-		APISession:      t.gatewaySession,
+		APISession:      t.internalHubSession,
 		Collections:     t.collections,
 		IPFSClient:      ic,
 		EmailSessionBus: t.emailSessionBus,
@@ -377,6 +386,9 @@ func (t *Textile) Close(force bool) error {
 		t.server.Stop()
 	} else {
 		t.server.GracefulStop()
+	}
+	if err := t.archiveTracker.Close(); err != nil {
+		return err
 	}
 	if err := t.bucks.Close(); err != nil {
 		return err
@@ -431,7 +443,7 @@ func (t *Textile) authFunc(ctx context.Context) (context.Context, error) {
 	sid, ok := common.SessionFromMD(ctx)
 	if ok {
 		ctx = common.NewSessionContext(ctx, sid)
-		if sid == t.gatewaySession {
+		if sid == t.internalHubSession {
 			return ctx, nil
 		}
 		session, err := t.collections.Sessions.Get(ctx, sid)
@@ -561,7 +573,7 @@ func (t *Textile) threadInterceptor() grpc.UnaryServerInterceptor {
 				return nil, status.Error(codes.PermissionDenied, "Method is not accessible")
 			}
 		}
-		if sid, ok := common.SessionFromContext(ctx); ok && sid == t.gatewaySession {
+		if sid, ok := common.SessionFromContext(ctx); ok && sid == t.internalHubSession {
 			return handler(ctx, req)
 		}
 
@@ -573,7 +585,6 @@ func (t *Textile) threadInterceptor() grpc.UnaryServerInterceptor {
 		} else if user, ok := mdb.UserFromContext(ctx); ok {
 			owner = user.Key
 		}
-		key, _ := mdb.APIKeyFromContext(ctx)
 
 		var newID thread.ID
 		var isDB bool
@@ -624,7 +635,9 @@ func (t *Textile) threadInterceptor() grpc.UnaryServerInterceptor {
 				}
 				if owner == nil || !owner.Equals(th.Owner) { // Linter can't see that owner can't be nil
 					return nil, status.Error(codes.PermissionDenied, "User does not own thread")
+
 				}
+				key, _ := mdb.APIKeyFromContext(ctx)
 				if key != nil && key.Type == mdb.UserKey {
 					// Extra user check for user API keys.
 					if key.Key != th.Key {

--- a/go.sum
+++ b/go.sum
@@ -1489,6 +1489,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/src-d/envconfig v1.0.0 h1:/AJi6DtjFhZKNx3OB2qMsq7y4yT5//AeSZIe7rk+PX8=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
@@ -1601,6 +1602,7 @@ github.com/whyrusleeping/pubsub v0.0.0-20131020042734-02de8aa2db3d/go.mod h1:g7c
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee h1:lYbXeSvJi5zk5GLKVuid9TVjS9a0OmLIDKTfoZBL6Ow=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
 github.com/whyrusleeping/yamux v1.1.5/go.mod h1:E8LnQQ8HKx5KD29HZFUwM1PxCOdPRzGwur1mcYhXcD8=
+github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
@@ -2050,6 +2052,7 @@ gopkg.in/ini.v1 v1.55.0 h1:E8yzL5unfpW3M6fz/eB7Cb5MQAYSZ7GKo4Qth+N2sgQ=
 gopkg.in/ini.v1 v1.55.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/src-d/go-cli.v0 v0.0.0-20181105080154-d492247bbc0d/go.mod h1:z+K8VcOYVYcSwSjGebuDL6176A1XskgbtNl64NSg+n8=
+gopkg.in/src-d/go-log.v1 v1.0.1 h1:heWvX7J6qbGWbeFS/aRmiy1eYaT+QMV6wNvHDyMjQV4=
 gopkg.in/src-d/go-log.v1 v1.0.1/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFabTyABE=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/mail/local/mailbox_test.go
+++ b/mail/local/mailbox_test.go
@@ -136,7 +136,6 @@ func (c *eventCollector) collect(events chan MailboxEvent) {
 		}
 		c.Unlock()
 	}
-	return
 }
 
 func (c *eventCollector) check(t *testing.T, numNew, numRead, numDeleted int) {

--- a/mongodb/archivetracking.go
+++ b/mongodb/archivetracking.go
@@ -118,11 +118,12 @@ func (at *ArchiveTracking) Finalize(ctx context.Context, jid ffs.JobID, cause st
 	return nil
 }
 
-func (at *ArchiveTracking) Reschedule(ctx context.Context, jid ffs.JobID, dur time.Duration) error {
+func (at *ArchiveTracking) Reschedule(ctx context.Context, jid ffs.JobID, dur time.Duration, cause string) error {
 	readyAt := time.Now().Add(dur)
 	res, err := at.col.UpdateOne(ctx, bson.M{"_id": jid}, bson.M{
 		"$set": bson.M{
 			"ready_at": readyAt,
+			"cause":    cause,
 		},
 	})
 	if err != nil {

--- a/mongodb/archivetracking.go
+++ b/mongodb/archivetracking.go
@@ -1,0 +1,164 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/textileio/go-threads/core/thread"
+	"github.com/textileio/powergate/ffs"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type TrackedArchive struct {
+	JID        ffs.JobID
+	DbID       thread.ID
+	DbToken    thread.Token
+	BucketKey  string
+	BucketRoot cid.Cid
+	ReadyAt    time.Time
+	Cause      string
+	Active     bool
+}
+
+// trackedArchive is an internal representation for storage.
+// Any field modifications should be reflected in the cast() func.
+type trackedArchive struct {
+	JID        ffs.JobID    `bson:"_id"`
+	DbID       thread.ID    `bson:"db_id"`
+	DbToken    thread.Token `bson:"db_token"`
+	BucketKey  string       `bson:"bucket_key"`
+	BucketRoot []byte       `bson:"bucket_root"`
+	ReadyAt    time.Time    `bson:"ready_at"`
+	Cause      string       `bson:"cause"`
+	Active     bool         `bson:"active"`
+}
+
+type ArchiveTracking struct {
+	col *mongo.Collection
+}
+
+func NewArchiveTracking(ctx context.Context, db *mongo.Database) (*ArchiveTracking, error) {
+	s := &ArchiveTracking{
+		col: db.Collection("archivetrackings"),
+	}
+	return s, nil
+}
+
+func (at *ArchiveTracking) Create(ctx context.Context, dbID thread.ID, dbToken thread.Token, bucketKey string, jid ffs.JobID, bucketRoot cid.Cid) error {
+	newTA := trackedArchive{
+		JID:        jid,
+		DbID:       dbID,
+		DbToken:    dbToken,
+		BucketKey:  bucketKey,
+		BucketRoot: bucketRoot.Bytes(),
+		ReadyAt:    time.Now(),
+		Cause:      "",
+		Active:     true,
+	}
+	_, err := at.col.InsertOne(ctx, newTA)
+	if err != nil {
+		return fmt.Errorf("inserting in collection: %s", err)
+	}
+	return nil
+}
+
+func (at *ArchiveTracking) GetReadyToCheck(ctx context.Context, n int64) ([]*TrackedArchive, error) {
+	opts := options.Find()
+	opts.SetLimit(n)
+	filter := bson.M{"ready_at": bson.M{"$lte": time.Now()}, "active": true}
+	cursor, err := at.col.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, fmt.Errorf("querying ready tracked archives: %s", err)
+	}
+	defer cursor.Close(ctx)
+	var tas []*trackedArchive
+	for cursor.Next(ctx) {
+		var ta trackedArchive
+		if err := cursor.Decode(&ta); err != nil {
+			return nil, err
+		}
+		tas = append(tas, &ta)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	return castSlice(tas)
+}
+
+func (at *ArchiveTracking) Get(ctx context.Context, jid ffs.JobID) (*TrackedArchive, error) {
+	filter := bson.M{"_id": jid}
+	res := at.col.FindOne(ctx, filter)
+	if res.Err() != nil {
+		return nil, fmt.Errorf("getting tracked archive: %s", res.Err())
+	}
+	var ta trackedArchive
+	if err := res.Decode(&ta); err != nil {
+		return nil, err
+	}
+	return cast(&ta)
+}
+
+func (at *ArchiveTracking) Finalize(ctx context.Context, jid ffs.JobID, cause string) error {
+	res, err := at.col.UpdateOne(ctx, bson.M{"_id": jid}, bson.M{
+		"$set": bson.M{
+			"active": false,
+			"cause":  cause,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+func (at *ArchiveTracking) Reschedule(ctx context.Context, jid ffs.JobID, dur time.Duration) error {
+	readyAt := time.Now().Add(dur)
+	res, err := at.col.UpdateOne(ctx, bson.M{"_id": jid}, bson.M{
+		"$set": bson.M{
+			"ready_at": readyAt,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+func cast(ta *trackedArchive) (*TrackedArchive, error) {
+	bckCid, err := cid.Cast(ta.BucketRoot)
+	if err != nil {
+		return nil, fmt.Errorf("casting bucket root: %s", err)
+	}
+	return &TrackedArchive{
+		JID:        ta.JID,
+		DbID:       ta.DbID,
+		DbToken:    ta.DbToken,
+		BucketKey:  ta.BucketKey,
+		BucketRoot: bckCid,
+		ReadyAt:    ta.ReadyAt,
+		Cause:      ta.Cause,
+		Active:     ta.Active,
+	}, nil
+}
+
+func castSlice(tas []*trackedArchive) ([]*TrackedArchive, error) {
+	ret := make([]*TrackedArchive, len(tas))
+	for i, ta := range tas {
+		castedTA, err := cast(ta)
+		if err != nil {
+			return nil, fmt.Errorf("casting tracked archive slice: %s", err)
+		}
+		ret[i] = castedTA
+	}
+	return ret, nil
+}

--- a/mongodb/archivetracking_test.go
+++ b/mongodb/archivetracking_test.go
@@ -123,7 +123,7 @@ func TestArchiveTracking_Reschedule(t *testing.T) {
 	err = col.Create(ctx, dbID, dbToken, bucketKey, jid, bucketRoot)
 	require.NoError(t, err)
 
-	err = col.Reschedule(ctx, jid, time.Hour+time.Second*5)
+	err = col.Reschedule(ctx, jid, time.Hour+time.Second*5, "retry me")
 	require.NoError(t, err)
 
 	ta, err := col.Get(ctx, jid)

--- a/mongodb/archivetracking_test.go
+++ b/mongodb/archivetracking_test.go
@@ -1,0 +1,134 @@
+package mongodb_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+	"github.com/textileio/go-threads/core/thread"
+	"github.com/textileio/powergate/ffs"
+	. "github.com/textileio/textile/mongodb"
+)
+
+func TestArchiveTracking_Create(t *testing.T) {
+	db := newDB(t)
+	col, err := NewArchiveTracking(context.Background(), db)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	dbID := thread.NewIDV1(thread.Raw, 16)
+	dbToken := thread.Token("token")
+	bucketKey := "buckKey"
+	jid := ffs.JobID("jobID1")
+	bucketRoot, _ := cid.Decode("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
+	err = col.Create(ctx, dbID, dbToken, bucketKey, jid, bucketRoot)
+	require.NoError(t, err)
+}
+
+func TestArchiveTracking_Get(t *testing.T) {
+	db := newDB(t)
+	col, err := NewArchiveTracking(context.Background(), db)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	dbID := thread.NewIDV1(thread.Raw, 16)
+	dbToken := thread.Token("token")
+	bucketKey := "buckKey"
+	jid := ffs.JobID("jobID1")
+	bucketRoot, _ := cid.Decode("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
+	err = col.Create(ctx, dbID, dbToken, bucketKey, jid, bucketRoot)
+	require.NoError(t, err)
+
+	ta, err := col.Get(ctx, jid)
+	require.NoError(t, err)
+	require.Equal(t, jid, ta.JID)
+	require.Equal(t, dbID, ta.DbID)
+	require.Equal(t, dbToken, ta.DbToken)
+	require.Equal(t, bucketKey, ta.BucketKey)
+	require.Equal(t, bucketRoot, ta.BucketRoot)
+	require.True(t, time.Since(ta.ReadyAt) > 0)
+	require.True(t, ta.Active)
+}
+
+func TestArchiveTracking_GetReadyToCheck(t *testing.T) {
+	db := newDB(t)
+	col, err := NewArchiveTracking(context.Background(), db)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	tas, err := col.GetReadyToCheck(ctx, 10)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(tas))
+
+	dbID := thread.NewIDV1(thread.Raw, 16)
+	dbToken := thread.Token("token")
+	bucketKey := "buckKey"
+	jid := ffs.JobID("jobID1")
+	bucketRoot, _ := cid.Decode("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
+	err = col.Create(ctx, dbID, dbToken, bucketKey, jid, bucketRoot)
+	require.NoError(t, err)
+
+	tas, err = col.GetReadyToCheck(ctx, 10)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(tas))
+	require.Equal(t, jid, tas[0].JID)
+	require.Equal(t, dbID, tas[0].DbID)
+	require.Equal(t, dbToken, tas[0].DbToken)
+	require.Equal(t, bucketKey, tas[0].BucketKey)
+	require.Equal(t, bucketRoot, tas[0].BucketRoot)
+	require.True(t, time.Since(tas[0].ReadyAt) > 0)
+	require.True(t, tas[0].Active)
+}
+
+func TestArchiveTracking_Finalize(t *testing.T) {
+	db := newDB(t)
+	col, err := NewArchiveTracking(context.Background(), db)
+	require.NoError(t, err)
+	ctx := context.Background()
+	dbID := thread.NewIDV1(thread.Raw, 16)
+	dbToken := thread.Token("token")
+	bucketKey := "buckKey"
+	jid := ffs.JobID("jobID1")
+	bucketRoot, _ := cid.Decode("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
+	err = col.Create(ctx, dbID, dbToken, bucketKey, jid, bucketRoot)
+	require.NoError(t, err)
+
+	cause := "all good"
+	err = col.Finalize(ctx, jid, cause)
+	require.NoError(t, err)
+
+	ta, err := col.Get(ctx, jid)
+	require.NoError(t, err)
+	require.False(t, ta.Active)
+	require.Equal(t, cause, ta.Cause)
+
+	tas, err := col.GetReadyToCheck(ctx, 10)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(tas))
+}
+
+func TestArchiveTracking_Reschedule(t *testing.T) {
+	db := newDB(t)
+	col, err := NewArchiveTracking(context.Background(), db)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	dbID := thread.NewIDV1(thread.Raw, 16)
+	dbToken := thread.Token("token")
+	bucketKey := "buckKey"
+	jid := ffs.JobID("jobID1")
+	bucketRoot, _ := cid.Decode("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
+	err = col.Create(ctx, dbID, dbToken, bucketKey, jid, bucketRoot)
+	require.NoError(t, err)
+
+	err = col.Reschedule(ctx, jid, time.Hour+time.Second*5)
+	require.NoError(t, err)
+
+	ta, err := col.Get(ctx, jid)
+	require.NoError(t, err)
+	require.True(t, ta.ReadyAt.Sub(time.Now()) > time.Hour)
+	require.True(t, ta.Active)
+
+}

--- a/mongodb/archivetracking_test.go
+++ b/mongodb/archivetracking_test.go
@@ -128,7 +128,7 @@ func TestArchiveTracking_Reschedule(t *testing.T) {
 
 	ta, err := col.Get(ctx, jid)
 	require.NoError(t, err)
-	require.True(t, ta.ReadyAt.Sub(time.Now()) > time.Hour)
+	require.True(t, time.Until(ta.ReadyAt) > time.Hour)
 	require.True(t, ta.Active)
 
 }

--- a/mongodb/collections.go
+++ b/mongodb/collections.go
@@ -23,10 +23,11 @@ type Collections struct {
 	Accounts *Accounts
 	Invites  *Invites
 
-	Threads      *Threads
-	APIKeys      *APIKeys
-	IPNSKeys     *IPNSKeys
-	FFSInstances *FFSInstances
+	Threads         *Threads
+	APIKeys         *APIKeys
+	IPNSKeys        *IPNSKeys
+	FFSInstances    *FFSInstances
+	ArchiveTracking *ArchiveTracking
 
 	Users *Users
 }
@@ -62,6 +63,10 @@ func NewCollections(ctx context.Context, uri, dbName string, hub bool) (*Collect
 			return nil, err
 		}
 		c.Users, err = NewUsers(ctx, db)
+		if err != nil {
+			return nil, err
+		}
+		c.ArchiveTracking, err = NewArchiveTracking(ctx, db)
 		if err != nil {
 			return nil, err
 		}

--- a/threaddb/buckets.go
+++ b/threaddb/buckets.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/textileio/powergate/ffs"
 	"github.com/textileio/textile/buckets"
 	mdb "github.com/textileio/textile/mongodb"
-	"github.com/textileio/textile/util"
 )
 
 var (
@@ -253,90 +251,6 @@ func ensureNoNulls(b *Bucket) {
 	}
 }
 
-// Archive pushes the current root Cid to the corresponding FFS instance of the bucket.
-// The behaviour changes depending on different cases, depending on a previous archive.
-// 0. No previous archive or last one aborted: simply pushes the Cid to the FFS instance.
-// 1. Last archive exists with the same Cid:
-//   a. Last archive Successful: fails, there's nothing to do.
-//   b. Last archive Executing/Queued: fails, that work already starting and is in progress.
-//   c. Last archive Failed/Canceled: work to do, push again with override flag to try again.
-// 2. Archiving on new Cid: work to do, it will always call Replace(,) in the FFS instance.
-func (b *Buckets) Archive(ctx context.Context, dbID thread.ID, key string, newCid cid.Cid, opts ...Option) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-	ffsi, err := b.ffsCol.Get(ctx, key)
-	if err != nil {
-		return fmt.Errorf("getting ffs instance data: %s", err)
-	}
-
-	ctxFFS := context.WithValue(ctx, powc.AuthKey, ffsi.FFSToken)
-
-	// Check that FFS wallet addr balance is > 0, if not, fail fast.
-	bal, err := b.pgClient.Wallet.WalletBalance(ctx, ffsi.WalletAddr)
-	if err != nil {
-		return fmt.Errorf("getting ffs wallet address balance: %s", err)
-	}
-	if bal == 0 {
-		return buckets.ErrZeroBalance
-	}
-
-	var jid ffs.JobID
-	firstTimeArchive := ffsi.Archives.Current.JobID == ""
-	if firstTimeArchive || ffsi.Archives.Current.Aborted { // Case 0.
-		// On the first archive, we simply push the Cid with
-		// the default CidConfig configured at bucket creation.
-		jid, err = b.pgClient.FFS.PushConfig(ctxFFS, newCid, powc.WithOverride(true))
-		if err != nil {
-			return fmt.Errorf("pushing config: %s", err)
-		}
-	} else {
-		oldCid, err := cid.Cast(ffsi.Archives.Current.Cid)
-		if err != nil {
-			return fmt.Errorf("parsing old Cid archive: %s", err)
-		}
-
-		if oldCid.Equals(newCid) { // Case 1.
-			switch ffs.JobStatus(ffsi.Archives.Current.JobStatus) {
-			// Case 1.a.
-			case ffs.Success:
-				return fmt.Errorf("the same bucket cid is already archived successfully")
-			// Case 1.b.
-			case ffs.Executing, ffs.Queued:
-				return fmt.Errorf("there is an in progress archive")
-			// Case 1.c.
-			case ffs.Failed, ffs.Canceled:
-				jid, err = b.pgClient.FFS.PushConfig(ctxFFS, newCid, powc.WithOverride(true))
-				if err != nil {
-					return fmt.Errorf("pushing config: %s", err)
-				}
-			default:
-				return fmt.Errorf("unexpected current archive status: %d", ffsi.Archives.Current.JobStatus)
-			}
-		} else { // Case 2.
-			jid, err = b.pgClient.FFS.Replace(ctxFFS, oldCid, newCid)
-			if err != nil {
-				return fmt.Errorf("replacing cid: %s", err)
-			}
-		}
-
-		// Include the existing archive in history,
-		// since we're going to set a new _current_ archive.
-		ffsi.Archives.History = append(ffsi.Archives.History, ffsi.Archives.Current)
-	}
-	ffsi.Archives.Current = mdb.Archive{
-		Cid:       newCid.Bytes(),
-		CreatedAt: time.Now().Unix(),
-		JobID:     jid.String(),
-		JobStatus: int(ffs.Queued),
-	}
-	if err := b.ffsCol.Replace(ctx, ffsi); err != nil {
-		return fmt.Errorf("updating ffs instance data: %s", err)
-	}
-	go b.trackArchiveProgress(util.NewClonedContext(ctx), dbID, key, jid, ffsi.FFSToken, newCid, opts...)
-
-	return nil
-}
-
 // ArchiveStatus returns the last known archive status on Powergate. If the return status is Failed,
 // an extra string with the error message is provided.
 func (b *Buckets) ArchiveStatus(ctx context.Context, key string) (ffs.JobStatus, string, error) {
@@ -395,147 +309,4 @@ func (b *Buckets) Close() error {
 	b.cancel()
 	b.wg.Wait()
 	return nil
-}
-
-func (b *Buckets) trackArchiveProgress(ctx context.Context, dbID thread.ID, key string, jid ffs.JobID, ffsToken string, c cid.Cid, opts ...Option) {
-	b.wg.Add(1)
-	defer b.wg.Done()
-
-	// Step 1: watch for the Job status, and keep updating on Mongo until
-	// we're in a final state.
-	ctx = context.WithValue(ctx, powc.AuthKey, ffsToken)
-	ch := make(chan powc.JobEvent, 1)
-	if err := b.pgClient.FFS.WatchJobs(ctx, ch, jid); err != nil {
-		log.Errorf("watching current job %s for bucket %s: %s", jid, key, err)
-		return
-	}
-
-	var aborted bool
-	var abortMsg string
-	var job ffs.Job
-Loop:
-	for {
-		select {
-		case <-b.ctx.Done():
-			log.Infof("job %s status watching canceled", jid)
-			return
-		case s, ok := <-ch:
-			if !ok {
-				log.Errorf("getting job %s status stream closed", jid)
-				aborted = true
-				abortMsg = "server closed communication channel"
-				break Loop
-			}
-			if s.Err != nil {
-				log.Errorf("job %s update: %s", jid, s.Err)
-				aborted = true
-				abortMsg = s.Err.Error()
-				break Loop
-			}
-			if isJobStatusFinal(s.Job.Status) {
-				job = s.Job
-				log.Infof("archive job for bucket %s reached final state %s", key, ffs.JobStatusStr[s.Job.Status])
-				break Loop
-			}
-		}
-	}
-
-	if err := b.updateArchiveStatus(ctx, key, jid.String(), job, aborted, abortMsg); err != nil {
-		log.Errorf("updating archive status: %s", err)
-	}
-
-	// Step 2: On success, save Deal data in the underlying Bucket thread. On
-	// failure save the error message.
-	if job.Status == ffs.Success {
-		if err := b.saveDealsInArchive(ctx, key, dbID, ffsToken, c, opts...); err != nil {
-			log.Errorf("saving deal data in archive: %s", err)
-		}
-	}
-}
-
-func (b *Buckets) saveDealsInArchive(ctx context.Context, key string, dbID thread.ID, ffsToken string, c cid.Cid, opts ...Option) error {
-	buck := &Bucket{}
-	err := b.Get(ctx, dbID, key, buck, opts...)
-	if err != nil {
-		return fmt.Errorf("getting bucket for save deals: %s", err)
-	}
-	ctxFFS := context.WithValue(ctx, powc.AuthKey, ffsToken)
-	sh, err := b.pgClient.FFS.Show(ctxFFS, c)
-	if err != nil {
-		return fmt.Errorf("getting cid info: %s", err)
-	}
-
-	proposals := sh.GetCidInfo().GetCold().GetFilecoin().GetProposals()
-
-	deals := make([]Deal, len(proposals))
-	for i, p := range proposals {
-		deals[i] = Deal{
-			ProposalCid: p.GetProposalCid(),
-			Miner:       p.GetMiner(),
-		}
-	}
-	buck.Archives.Current = Archive{
-		Cid:   c.String(),
-		Deals: deals,
-	}
-
-	buck.UpdatedAt = time.Now().UnixNano()
-	if err = b.SaveSafe(ctx, dbID, buck, opts...); err != nil {
-		return fmt.Errorf("saving deals in thread: %s", err)
-	}
-	return nil
-}
-
-// updateArchiveStatus save the last known job status. It also receives an
-// _abort_ flag which indicates that the provided newJobStatus might not be
-// final. For example, if tracking the Job status changes errored by some network
-// condition, we have only the last known Job status. Powergate would continue doing
-// its work until a final status is reached; it only means we aren't sure how this
-// archive really finished.
-// To track for this situation, we use the _aborted_ and _abortMsg_ parameters.
-// An archive with _aborted_ true should eventually be re-queried to understand
-// how it finished (if wanted).
-func (b *Buckets) updateArchiveStatus(ctx context.Context, key string, jid string, job ffs.Job, aborted bool, abortMsg string) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-	ffsi, err := b.ffsCol.Get(ctx, key)
-	if err != nil {
-		return fmt.Errorf("getting ffs instance data: %s", err)
-	}
-
-	archive := &ffsi.Archives.Current
-	if archive.JobID != jid {
-		for i := range ffsi.Archives.History {
-			if ffsi.Archives.History[i].JobID == jid {
-				archive = &ffsi.Archives.History[i]
-				break
-			}
-		}
-	}
-	archive.JobStatus = int(job.Status)
-	archive.Aborted = aborted
-	archive.AbortedMsg = abortMsg
-	archive.FailureMsg = prepareFailureMsg(job)
-	if err := b.ffsCol.Replace(ctx, ffsi); err != nil {
-		return fmt.Errorf("updating ffs status update instance data: %s", err)
-	}
-	return nil
-}
-
-func isJobStatusFinal(js ffs.JobStatus) bool {
-	return js == ffs.Success ||
-		js == ffs.Canceled ||
-		js == ffs.Failed
-}
-
-func prepareFailureMsg(job ffs.Job) string {
-	if job.ErrCause == "" {
-		return ""
-	}
-	var b strings.Builder
-	_, _ = b.WriteString(job.ErrCause)
-	for i, de := range job.DealErrors {
-		_, _ = b.WriteString(fmt.Sprintf("\nDeal error %d: Proposal %s with miner %s, %s", i, de.ProposalCid, de.Miner, de.Message))
-	}
-	return b.String()
 }

--- a/threaddb/buckets.go
+++ b/threaddb/buckets.go
@@ -205,6 +205,8 @@ func (b *Buckets) IsArchivingEnabled() bool {
 }
 
 func (b *Buckets) createFFSInstance(ctx context.Context, bucketKey string) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
 	// If the Powergate client isn't configured, don't do anything.
 	if b.pgClient == nil {
 		return nil

--- a/threaddb/threaddb.go
+++ b/threaddb/threaddb.go
@@ -6,7 +6,6 @@ import (
 
 	logging "github.com/ipfs/go-log"
 	dbc "github.com/textileio/go-threads/api/client"
-	tc "github.com/textileio/go-threads/api/client"
 	coredb "github.com/textileio/go-threads/core/db"
 	"github.com/textileio/go-threads/core/thread"
 	"github.com/textileio/go-threads/db"
@@ -15,7 +14,7 @@ import (
 var log = logging.Logger("threaddb")
 
 type collection struct {
-	c      *tc.Client
+	c      *dbc.Client
 	config db.CollectionConfig
 }
 


### PR DESCRIPTION
Closes #282, which already has an explanation of the intention of the change.

The gateway token was promoted to a more general concept. It is (and will be) used as an internal session to bypass auth interceptor in any internal logic of the Hub. This avoids the need of having to serialize auth information from dev/org/user and recover it out-of-request to perform actions on threads on its behalf.