### PR TITLE
increase chunk size in buckets client

### DIFF
--- a/api/buckets/client/client.go
+++ b/api/buckets/client/client.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// chunkSize for add file requests.
-	chunkSize = 1024
+	chunkSize = 1024 * 32
 )
 
 // Client provides the client api.


### PR DESCRIPTION
After some tests, it improves the upload speed since more volume of real data is sent per roundtrip to the Hub.
Improves uploading speed using the CLI.