### PR TITLE
provide default handling when enum is unspecified

### DIFF
--- a/api/hub/service.go
+++ b/api/hub/service.go
@@ -237,6 +237,7 @@ func (s *Service) CreateKey(ctx context.Context, req *pb.CreateKeyRequest) (*pb.
 	var keyType mdb.APIKeyType
 	switch req.Type {
 	case pb.KeyType_KEY_TYPE_ACCOUNT:
+	case pb.KeyType_KEY_TYPE_UNSPECIFIED:
 		keyType = mdb.AccountKey
 	case pb.KeyType_KEY_TYPE_USER:
 		keyType = mdb.UserKey

--- a/api/users/service.go
+++ b/api/users/service.go
@@ -290,6 +290,7 @@ func getMailboxQuery(seek string, limit int64, asc bool, stat pb.ListInboxMessag
 	q.LimitTo(int(limit))
 	switch stat {
 	case pb.ListInboxMessagesRequest_STATUS_ALL:
+	case pb.ListInboxMessagesRequest_STATUS_UNSPECIFIED:
 		break
 	case pb.ListInboxMessagesRequest_STATUS_READ:
 		q.And("read_at").Gt(minMessageReadAt)


### PR DESCRIPTION
There are times when the client doesn't specify the value of an enum parameter to a call. This means the `0` value is assigned. Previously, the `0` value had a meaning on the server (`All` inbox messages, for example), but now `0` is, correctly, `Unspecified`. In cases where we receive `Unspecified` on the server, we should provide a default value. This is nice because it keeps the decision about default values on the server and that logic can be changed at any time, independent of the client.

Pretty simple, will take a review from whoever can do it first. Need to get a rc release out with this fix asap.