### PR TITLE
GetOrCeate BucketArchive, better error messages

### DIFF
--- a/buckets/archive/tracker.go
+++ b/buckets/archive/tracker.go
@@ -98,7 +98,7 @@ func (t *Tracker) run() {
 						}
 
 						if powInfo == nil {
-							if err := t.colls.ArchiveTracking.Finalize(ctx, a.JID, "huh? no FFS info, weird"); err != nil {
+							if err := t.colls.ArchiveTracking.Finalize(ctx, a.JID, "no powergate info found"); err != nil {
 								log.Errorf("finalizing errored/rescheduled archive tracking: %s", err)
 							}
 							return
@@ -211,7 +211,7 @@ func (t *Tracker) trackArchiveProgress(ctx context.Context, buckKey string, dbID
 func (t *Tracker) updateArchiveStatus(ctx context.Context, buckKey string, job ffs.Job, aborted bool, abortMsg string) error {
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	ba, err := t.colls.BucketArchives.Get(ctx, buckKey)
+	ba, err := t.colls.BucketArchives.GetOrCreate(ctx, buckKey)
 	if err != nil {
 		return fmt.Errorf("getting BucketArchive data: %s", err)
 	}
@@ -229,7 +229,7 @@ func (t *Tracker) updateArchiveStatus(ctx context.Context, buckKey string, job f
 	lastArchive.AbortedMsg = abortMsg
 	lastArchive.FailureMsg = prepareFailureMsg(job)
 	if err := t.colls.BucketArchives.Replace(ctx, ba); err != nil {
-		return fmt.Errorf("updating ffs status update instance data: %s", err)
+		return fmt.Errorf("updating bucket archives status: %s", err)
 	}
 	return nil
 }

--- a/buckets/buckets.go
+++ b/buckets/buckets.go
@@ -21,6 +21,6 @@ var (
 	ErrNoCurrentArchive = fmt.Errorf("the bucket was never archived")
 
 	// ErrZeroBalance is returned when archiving a bucket which
-	// underlying FFS instance balance is zero.
-	ErrZeroBalance = errors.New("bucket FIL balance is zero, if recently created wait 30s")
+	// underlying Account/User FFS instance balance is zero.
+	ErrZeroBalance = errors.New("powergate wallet FIL balance is zero, if recently created wait 30s")
 )

--- a/core/core.go
+++ b/core/core.go
@@ -679,7 +679,7 @@ func generatePowUnaryInterceptor(serviceName string, allowedMethods []string, se
 		createNewFFS := func() error {
 			id, token, err := pc.FFS.Create(ctx)
 			if err != nil {
-				return fmt.Errorf("creating new ffs instance: %v", err)
+				return fmt.Errorf("creating new powergate integration: %v", err)
 			}
 			if isAccount {
 				_, err = c.Accounts.UpdatePowInfo(ctx, owner, &mdb.PowInfo{ID: id, Token: token})
@@ -687,7 +687,7 @@ func generatePowUnaryInterceptor(serviceName string, allowedMethods []string, se
 				_, err = c.Users.UpdatePowInfo(ctx, owner, &mdb.PowInfo{ID: id, Token: token})
 			}
 			if err != nil {
-				return fmt.Errorf("updating user/account with new ffs information: %v", err)
+				return fmt.Errorf("updating user/account with new powergate information: %v", err)
 			}
 			return nil
 		}

--- a/mongodb/bucketarchives_test.go
+++ b/mongodb/bucketarchives_test.go
@@ -15,8 +15,9 @@ func TestBucketArchives_Create(t *testing.T) {
 	col, err := NewBucketArchives(context.Background(), db)
 	require.NoError(t, err)
 
-	err = col.Create(context.Background(), "buckkey1")
+	res, err := col.Create(context.Background(), "buckkey1")
 	require.NoError(t, err)
+	require.Equal(t, "buckkey1", res.BucketKey)
 }
 
 func TestBucketArchives_Get(t *testing.T) {
@@ -24,10 +25,11 @@ func TestBucketArchives_Get(t *testing.T) {
 	col, err := NewBucketArchives(context.Background(), db)
 	require.NoError(t, err)
 
-	err = col.Create(context.Background(), "buckkey1")
+	res, err := col.Create(context.Background(), "buckkey1")
 	require.NoError(t, err)
+	require.Equal(t, "buckkey1", res.BucketKey)
 
-	got, err := col.Get(context.Background(), "buckkey1")
+	got, err := col.GetOrCreate(context.Background(), "buckkey1")
 	require.NoError(t, err)
 	require.Equal(t, "buckkey1", got.BucketKey)
 }
@@ -38,10 +40,11 @@ func TestBucketArchives_Replace(t *testing.T) {
 	col, err := NewBucketArchives(context.Background(), db)
 	require.NoError(t, err)
 
-	err = col.Create(context.Background(), "buckkey1")
+	res, err := col.Create(context.Background(), "buckkey1")
 	require.NoError(t, err)
+	require.Equal(t, "buckkey1", res.BucketKey)
 
-	ffs, err := col.Get(context.Background(), "buckkey1")
+	ffs, err := col.GetOrCreate(context.Background(), "buckkey1")
 	require.NoError(t, err)
 
 	c1, _ := cid.Decode("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
@@ -63,7 +66,7 @@ func TestBucketArchives_Replace(t *testing.T) {
 	err = col.Replace(ctx, ffs)
 	require.NoError(t, err)
 
-	ffs2, err := col.Get(context.Background(), "buckkey1")
+	ffs2, err := col.GetOrCreate(context.Background(), "buckkey1")
 	require.NoError(t, err)
 	require.Equal(t, ffs, ffs2)
 }


### PR DESCRIPTION
This fixes an edge case where a Bucket exists before archiving was implemented so its `BucketArchive` record can't be found. Also removes the "ffs" wording from publicly exposed error messages and a couple places where "bucket archive" as incorrectly referred to as "ffs".