### PR TITLE
Use contains to check for auth token not found

### DIFF
--- a/api/buckets/service.go
+++ b/api/buckets/service.go
@@ -1653,7 +1653,7 @@ func (s *Service) Archive(ctx context.Context, req *pb.ArchiveRequest) (*pb.Arch
 
 	defConf, err := s.PGClient.FFS.DefaultStorageConfig(ctxFFS)
 	if err != nil {
-		if err.Error() != "auth token not found" {
+		if !strings.Contains(err.Error(), "auth token not found") {
 			return nil, fmt.Errorf("getting powergate default StorageConfig: %v", err)
 		} else {
 			// case where the ffs token is no longer valid because powergate was reset.

--- a/buckets/archive/tracker.go
+++ b/buckets/archive/tracker.go
@@ -87,7 +87,7 @@ func (t *Tracker) run() {
 					go func(a *mdb.TrackedArchive) {
 						defer wg.Done()
 
-						ctx, cancel := context.WithTimeout(t.ctx, time.Second*5)
+						ctx, cancel := context.WithTimeout(t.ctx, time.Second*10)
 						defer cancel()
 
 						var powInfo *mdb.PowInfo
@@ -151,7 +151,7 @@ func (t *Tracker) trackArchiveProgress(ctx context.Context, buckKey string, dbID
 	if err := t.pgClient.FFS.WatchJobs(ctx, ch, jid); err != nil {
 		// if error specifies that the auth token isn't found, powergate must have been reset.
 		// return the error as fatal so the archive will be untracked
-		if err.Error() == "auth token not found" {
+		if strings.Contains(err.Error(), "auth token not found") {
 			return false, "", err
 		}
 		return true, fmt.Sprintf("watching current job %s for bucket %s: %s", jid, buckKey, err), nil

--- a/core/core.go
+++ b/core/core.go
@@ -712,7 +712,7 @@ func generatePowUnaryInterceptor(serviceName string, allowedMethods []string, se
 
 		res, err := stub.InvokeRpc(ffsCtx, methodDesc, req.(proto.Message))
 		if err != nil {
-			if err.Error() != "auth token not found" {
+			if !strings.Contains(err.Error(), "auth token not found") {
 				return nil, err
 			} else {
 				// case where the ffs token is no longer valid because powergate was reset.


### PR DESCRIPTION
Use `strings.Contains` to check for auth FFS recreation logic.