### PR TITLE
archive/tracker: fail if job is not found

### DIFF
--- a/buckets/archive/tracker.go
+++ b/buckets/archive/tracker.go
@@ -154,6 +154,9 @@ func (t *Tracker) trackArchiveProgress(ctx context.Context, buckKey string, dbID
 		if strings.Contains(err.Error(), "auth token not found") {
 			return false, "", err
 		}
+		if strings.Contains(err.Error(), "job not found") {
+			return false, "", err
+		}
 		return true, fmt.Sprintf("watching current job %s for bucket %s: %s", jid, buckKey, err), nil
 	}
 


### PR DESCRIPTION
Consider another border case apart from FFS resets.
See https://github.com/textileio/powergate/pull/589.