### PR TITLE
finalize aborted tracking

### DIFF
--- a/buckets/archive/tracker.go
+++ b/buckets/archive/tracker.go
@@ -154,9 +154,6 @@ func (t *Tracker) trackArchiveProgress(ctx context.Context, buckKey string, dbID
 		if strings.Contains(err.Error(), "auth token not found") {
 			return false, "", err
 		}
-		if strings.Contains(err.Error(), "job not found") {
-			return false, "", err
-		}
 		return true, fmt.Sprintf("watching current job %s for bucket %s: %s", jid, buckKey, err), nil
 	}
 
@@ -179,7 +176,7 @@ func (t *Tracker) trackArchiveProgress(ctx context.Context, buckKey string, dbID
 		job = s.Job
 	}
 
-	if !isJobStatusFinal(job.Status) {
+	if !aborted && !isJobStatusFinal(job.Status) {
 		return true, "no final status yet", nil
 	}
 


### PR DESCRIPTION
This is a small change compared to the previous PR.

The _job not found error_ is returned in a result in the channel, not in the originated API call. 
Also, this handles correctly other errors that might appear in the future.

In short: if we got an error in the communication channel, we should finalize the tracking.