### PR TITLE
Allow to print archive logs on success

### DIFF
--- a/buckets/local/archive.go
+++ b/buckets/local/archive.go
@@ -111,11 +111,9 @@ func (b *Bucket) ArchiveStatus(ctx context.Context, watch bool) (<-chan ArchiveS
 					return
 				}
 				scancel()
-				final, err := isJobStatusFinal(r.GetStatus())
+				_, err = isJobStatusFinal(r.GetStatus())
 				if err != nil {
 					msgs <- ArchiveStatusMessage{Type: ArchiveError, Error: err}
-					cancel()
-				} else if final {
 					cancel()
 				}
 			}


### PR DESCRIPTION
Improve CLI experience allowing to print all logs on _watch_ mode if archive finished successfully. 