### PR TITLE
Hotfix/buckets-acl: use correct names in cross user method list.

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -123,8 +123,8 @@ var (
 		"/api.buckets.pb.APIService/PullPath",
 		"/api.buckets.pb.APIService/SetPath",
 		"/api.buckets.pb.APIService/RemovePath",
-		"/api.buckets.pb.APIService/GetPathAccessRoles",
-		"/api.buckets.pb.APIService/EditPathAccessRoles",
+		"/api.buckets.pb.APIService/PullPathAccessRoles",
+		"/api.buckets.pb.APIService/PushPathAccessRoles",
 	}
 
 	// WSPingInterval controls the WebSocket keepalive pinging interval. Must be >= 1s.


### PR DESCRIPTION
Note: I updated our dev instance of the hub to use this version and it's working.  However when I run `go test ./...` it hangs.  I was able to compile `buckd` and `hubd` fine as well. Let me know if there are any steps to get all the tests working and if there are any other steps I should do before making the PR as per your local dev process.