### PR TITLE
Update to threads w/ txn errors

### DIFF
--- a/api/hub/service.go
+++ b/api/hub/service.go
@@ -34,7 +34,7 @@ import (
 var (
 	log = logging.Logger("hubapi")
 
-	loginTimeout = time.Minute * 3
+	loginTimeout = time.Minute * 30
 	emailTimeout = time.Second * 10
 )
 

--- a/api/users/client/client_test.go
+++ b/api/users/client/client_test.go
@@ -627,6 +627,7 @@ func TestUserBuckets(t *testing.T) {
 	assert.False(t, file1Root2.Cid().Equals(file1Root.Cid()))
 
 	// Check that we now have two logs in the bucket thread
+	time.Sleep(time.Second)
 	info, err := net.GetThread(ctx, dbID, corenet.WithThreadToken(tok))
 	require.NoError(t, err)
 	assert.Len(t, info.Logs, 2)

--- a/buckets/local/bucket.go
+++ b/buckets/local/bucket.go
@@ -178,13 +178,16 @@ func pbRootToInfo(r *pb.Root) (info Info, err error) {
 	if err != nil {
 		return
 	}
-	roles, err := buckets.RolesFromPb(r.Metadata.Roles)
-	if err != nil {
-		return
-	}
-	md := Metadata{
-		Roles:     roles,
-		UpdatedAt: time.Unix(0, r.Metadata.UpdatedAt),
+	md := Metadata{}
+	if r.Metadata != nil {
+		roles, err := buckets.RolesFromPb(r.Metadata.Roles)
+		if err != nil {
+			return info, err
+		}
+		md = Metadata{
+			Roles:     roles,
+			UpdatedAt: time.Unix(0, r.Metadata.UpdatedAt),
+		}
 	}
 	return Info{
 		Key:       r.Key,

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/textileio/dcrypto v0.0.1
 	github.com/textileio/go-assets v0.0.0-20200430191519-b341e634e2b7
-	github.com/textileio/go-threads v0.1.24-0.20200917051435-db9fbf6df883
+	github.com/textileio/go-threads v0.1.24-0.20200917053427-f4a9ab7691f9
 	github.com/textileio/powergate v0.6.0-rc2
 	github.com/textileio/uiprogress v0.0.4
 	go.mongodb.org/mongo-driver v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/textileio/dcrypto v0.0.1
 	github.com/textileio/go-assets v0.0.0-20200430191519-b341e634e2b7
-	github.com/textileio/go-threads v0.1.24-0.20200916184629-5d3f3d5e7d0b
+	github.com/textileio/go-threads v0.1.24-0.20200917051435-db9fbf6df883
 	github.com/textileio/powergate v0.6.0-rc2
 	github.com/textileio/uiprogress v0.0.4
 	go.mongodb.org/mongo-driver v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1600,8 +1600,8 @@ github.com/textileio/go-ds-badger v0.2.5-0.20200819232634-de89720b5d6a h1:AdjNdw
 github.com/textileio/go-ds-badger v0.2.5-0.20200819232634-de89720b5d6a/go.mod h1:0kLVpG7eeM95s4rS78lQe4eG5DCk+cnU8xas2nPSdZY=
 github.com/textileio/go-ds-mongo v0.1.0 h1:aZrsVQ1R52x65Zv6QsH3kM1bnR3oyVzEuAjCwZ63GkE=
 github.com/textileio/go-ds-mongo v0.1.0/go.mod h1:9wmGTUr+MWidGxYQe27RuCogEUZ7vnQxZb4GWj7uWL8=
-github.com/textileio/go-threads v0.1.24-0.20200916184629-5d3f3d5e7d0b h1:gedTSVYLhwMTHXvlwtft0rkJzYJO07FSzpRRggp4NdI=
-github.com/textileio/go-threads v0.1.24-0.20200916184629-5d3f3d5e7d0b/go.mod h1:NxNoGoZ5Fa1DZafkuqliOTtWt97aiTUmA3NpDayhv/w=
+github.com/textileio/go-threads v0.1.24-0.20200917051435-db9fbf6df883 h1:QaORTFg9KyWNZxSflsvm7OaYyoA7Kv4VaZRZdrgzsxc=
+github.com/textileio/go-threads v0.1.24-0.20200917051435-db9fbf6df883/go.mod h1:NxNoGoZ5Fa1DZafkuqliOTtWt97aiTUmA3NpDayhv/w=
 github.com/textileio/powergate v0.6.0-rc2 h1:owH94RVeDWr7tf3BQbq2NE7XPFGEQ0CLJ+yfNa+BV5o=
 github.com/textileio/powergate v0.6.0-rc2/go.mod h1:7wiqjP17XLs8LYwgIlRqtp6W2LQgUDIcj7uelFKS/O0=
 github.com/textileio/uiprogress v0.0.4 h1:7FWXEKK/h54ssNOW24q9MeJ9Eujptsr8eDPq35aPHjo=

--- a/go.sum
+++ b/go.sum
@@ -1600,8 +1600,8 @@ github.com/textileio/go-ds-badger v0.2.5-0.20200819232634-de89720b5d6a h1:AdjNdw
 github.com/textileio/go-ds-badger v0.2.5-0.20200819232634-de89720b5d6a/go.mod h1:0kLVpG7eeM95s4rS78lQe4eG5DCk+cnU8xas2nPSdZY=
 github.com/textileio/go-ds-mongo v0.1.0 h1:aZrsVQ1R52x65Zv6QsH3kM1bnR3oyVzEuAjCwZ63GkE=
 github.com/textileio/go-ds-mongo v0.1.0/go.mod h1:9wmGTUr+MWidGxYQe27RuCogEUZ7vnQxZb4GWj7uWL8=
-github.com/textileio/go-threads v0.1.24-0.20200917051435-db9fbf6df883 h1:QaORTFg9KyWNZxSflsvm7OaYyoA7Kv4VaZRZdrgzsxc=
-github.com/textileio/go-threads v0.1.24-0.20200917051435-db9fbf6df883/go.mod h1:NxNoGoZ5Fa1DZafkuqliOTtWt97aiTUmA3NpDayhv/w=
+github.com/textileio/go-threads v0.1.24-0.20200917053427-f4a9ab7691f9 h1:wf+wCYNwcm/PvxMFd5in4jijbPy2edT8ln8biHefZIg=
+github.com/textileio/go-threads v0.1.24-0.20200917053427-f4a9ab7691f9/go.mod h1:NxNoGoZ5Fa1DZafkuqliOTtWt97aiTUmA3NpDayhv/w=
 github.com/textileio/powergate v0.6.0-rc2 h1:owH94RVeDWr7tf3BQbq2NE7XPFGEQ0CLJ+yfNa+BV5o=
 github.com/textileio/powergate v0.6.0-rc2/go.mod h1:7wiqjP17XLs8LYwgIlRqtp6W2LQgUDIcj7uelFKS/O0=
 github.com/textileio/uiprogress v0.0.4 h1:7FWXEKK/h54ssNOW24q9MeJ9Eujptsr8eDPq35aPHjo=


### PR DESCRIPTION
Also fixes an issue where old buckets with `nil` `Metadata` caused a CLI panic. 