### PR TITLE
buck: adds role ls and roles grant cmds

### DIFF
--- a/api/buckets/client/client_test.go
+++ b/api/buckets/client/client_test.go
@@ -861,6 +861,26 @@ func pushPathAccessRoles(t *testing.T, ctx context.Context, userctx context.Cont
 			Read:  true,
 			Write: true,
 		})
+
+		// Grant root
+		err = client.PushPathAccessRoles(ctx, buck.Root.Key, "", map[string]bucks.Role{
+			user2.GetPublic().String(): bucks.Reader,
+		})
+		require.NoError(t, err)
+		checkAccess(t, user2ctx, client, accessCheck{
+			Key:   buck.Root.Key,
+			Path:  "a/f2",
+			Read:  true,
+			Write: true,
+		})
+
+		// Re-check nested access for user1
+		checkAccess(t, user1ctx, client, accessCheck{
+			Key:   buck.Root.Key,
+			Path:  "a/b/f1",
+			Read:  true,
+			Write: true,
+		})
 	})
 }
 

--- a/api/buckets/service.go
+++ b/api/buckets/service.go
@@ -264,6 +264,10 @@ func (s *Service) createBucket(ctx context.Context, dbID thread.ID, dbToken thre
 	now := time.Now()
 	md := map[string]tdb.Metadata{
 		"": tdb.NewDefaultMetadata(owner, fileKey, now),
+		buckets.SeedName: {
+			Roles:     make(map[string]buckets.Role),
+			UpdatedAt: now.UnixNano(),
+		},
 	}
 
 	// Create a new IPNS key

--- a/buckets/buckets.go
+++ b/buckets/buckets.go
@@ -3,6 +3,7 @@ package buckets
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/textileio/go-threads/core/thread"
 	pb "github.com/textileio/textile/api/buckets/pb"
@@ -24,6 +25,38 @@ const (
 	Writer
 	Admin
 )
+
+// NewRoleFromString returns the role associated with the given string.
+func NewRoleFromString(s string) (Role, error) {
+	switch strings.ToLower(s) {
+	case "none":
+		return None, nil
+	case "reader":
+		return Reader, nil
+	case "writer":
+		return Writer, nil
+	case "admin":
+		return Admin, nil
+	default:
+		return None, fmt.Errorf("invalid role: %s", s)
+	}
+}
+
+// String returns the string representation of the role.
+func (r Role) String() string {
+	switch r {
+	case None:
+		return "None"
+	case Reader:
+		return "Reader"
+	case Writer:
+		return "Writer"
+	case Admin:
+		return "Admin"
+	default:
+		return "Invalid"
+	}
+}
 
 var (
 	// ErrNonFastForward is returned when an update in non-fast-forward.

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -23,8 +23,9 @@ func init() {
 }
 
 func Init(baseCmd *cobra.Command) {
-	baseCmd.AddCommand(initCmd, linksCmd, rootCmd, statusCmd, lsCmd, pushCmd, pullCmd, addCmd, watchCmd, catCmd, destroyCmd, encryptCmd, decryptCmd, archiveCmd)
+	baseCmd.AddCommand(initCmd, linksCmd, rootCmd, statusCmd, lsCmd, pushCmd, pullCmd, addCmd, watchCmd, catCmd, destroyCmd, encryptCmd, decryptCmd, archiveCmd, rolesCmd)
 	archiveCmd.AddCommand(archiveStatusCmd, archiveInfoCmd)
+	rolesCmd.AddCommand(rolesGrantCmd, rolesLsCmd)
 
 	initCmd.PersistentFlags().String("key", "", "Bucket key")
 	initCmd.PersistentFlags().String("thread", "", "Thread ID")
@@ -48,6 +49,8 @@ func Init(baseCmd *cobra.Command) {
 	decryptCmd.Flags().StringP("password", "p", "", "Decryption password")
 
 	archiveStatusCmd.Flags().BoolP("watch", "w", false, "Watch execution log")
+
+	rolesGrantCmd.Flags().StringP("role", "r", "", "Access role: none, reader, writer, admin")
 }
 
 func SetBucks(b *local.Buckets) {

--- a/cmd/buck/cli/roles.go
+++ b/cmd/buck/cli/roles.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+	"github.com/textileio/textile/buckets"
+	"github.com/textileio/textile/cmd"
+)
+
+var rolesCmd = &cobra.Command{
+	Use: "roles",
+	Aliases: []string{
+		"role",
+	},
+	Short: "Object access role management",
+	Long:  `Manages remote bucket object access roles.`,
+	Args:  cobra.ExactArgs(0),
+}
+
+var rolesGrantCmd = &cobra.Command{
+	Use:   "grant [identity] [path]",
+	Short: "Grant remote object access roles",
+	Long: `Grants remote object access roles to an identity.
+
+Identity must be a multibase encoded public key. A "*" value will set the default access role for an object.
+
+Access roles:
+"none": Revokes all access.
+"reader": Grants read-only access.
+"writer": Grants read and write access.
+"admin": Grants read, write, delete and role editing access.
+`,
+	Args: cobra.RangeArgs(1, 2),
+	Run: func(c *cobra.Command, args []string) {
+		roleStr, err := c.Flags().GetString("role")
+		cmd.ErrCheck(err)
+		ctx, cancel := context.WithTimeout(context.Background(), cmd.PullTimeout)
+		defer cancel()
+		buck, err := bucks.GetLocalBucket(ctx, ".")
+		cmd.ErrCheck(err)
+		if roleStr == "" {
+			roles := []string{"None", "Reader", "Writer", "Admin"}
+			prompt := promptui.Select{
+				Label: "Select a role",
+				Items: roles,
+				Templates: &promptui.SelectTemplates{
+					Active:   fmt.Sprintf(`{{ "%s" | cyan }} {{ . | bold }}`, promptui.IconSelect),
+					Inactive: `{{ . | faint }}`,
+					Selected: aurora.Sprintf(aurora.BrightBlack("> Selected role {{ . | white | bold }}")),
+				},
+			}
+			index, _, err := prompt.Run()
+			if err != nil {
+				cmd.End("")
+			}
+			roleStr = roles[index]
+		}
+		role, err := buckets.NewRoleFromString(roleStr)
+		if err != nil {
+			cmd.Error(fmt.Errorf("access role must be one of: none, reader, writer, or admin"))
+		}
+		var pth string
+		if len(args) > 1 {
+			pth = args[1]
+		}
+		res, err := buck.PushPathAccessRoles(ctx, pth, map[string]buckets.Role{args[0]: role})
+		cmd.ErrCheck(err)
+		var data [][]string
+		if len(res) > 0 {
+			for i, r := range res {
+				data = append(data, []string{i, r.String()})
+			}
+		}
+		if len(data) > 0 {
+			cmd.RenderTable([]string{"identity", "role"}, data)
+		}
+		cmd.Success("Updated access roles for path %s", aurora.White(pth).Bold())
+	},
+}
+
+var rolesLsCmd = &cobra.Command{
+	Use: "ls [path]",
+	Aliases: []string{
+		"list",
+	},
+	Short: "List top-level or nested bucket object access roles",
+	Long:  `Lists top-level or nested bucket object access roles.`,
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(c *cobra.Command, args []string) {
+		ctx, cancel := context.WithTimeout(context.Background(), cmd.PullTimeout)
+		defer cancel()
+		buck, err := bucks.GetLocalBucket(ctx, ".")
+		cmd.ErrCheck(err)
+		var pth string
+		if len(args) > 0 {
+			pth = args[0]
+		}
+		res, err := buck.PullPathAccessRoles(ctx, pth)
+		cmd.ErrCheck(err)
+		var data [][]string
+		if len(res) > 0 {
+			for i, r := range res {
+				data = append(data, []string{i, r.String()})
+			}
+		}
+		if len(data) > 0 {
+			cmd.RenderTable([]string{"identity", "role"}, data)
+		}
+		cmd.Message("Found %d access roles", aurora.White(len(data)).Bold())
+	},
+}

--- a/threaddb/buckets.go
+++ b/threaddb/buckets.go
@@ -70,11 +70,6 @@ func NewDefaultMetadata(owner thread.PubKey, key []byte, ts time.Time) Metadata 
 	return md
 }
 
-// GetFileEncryptionKey returns the file encryption key as bytes if present.
-func (m *Metadata) GetFileEncryptionKey() []byte {
-	return keyBytes(m.Key)
-}
-
 // SetFileEncryptionKey sets the file encryption key.
 func (m *Metadata) SetFileEncryptionKey(key []byte) {
 	if key != nil {


### PR DESCRIPTION
Adds a new `buck roles` command with two sub-commands, `buck roles grant` and `buck roles ls`. Grant is used like,
```
buck roles grant [identity] [path]
```
Omitting `path` indicates the root. You can specify the role with `--role=none|reader|writer|admin`, otherwise a prompt appears.