### PR TITLE
cli: fix missing pb mapping & improve render table

### DIFF
--- a/buckets/local/archive.go
+++ b/buckets/local/archive.go
@@ -176,6 +176,7 @@ func pbArchiveInfoToArchiveInfo(pi *pb.ArchiveInfoResponse) (info ArchiveInfo, e
 				return
 			}
 		}
+		info.Archive.Deals = deals
 	}
 	return info, err
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -76,7 +76,7 @@ func RenderTable(header []string, data [][]string) {
 	table.SetBorder(false)
 	table.SetTablePadding("\t")
 	table.SetNoWhiteSpace(false)
-	headersColors := make([]tablewriter.Colors, len(data[0]))
+	headersColors := make([]tablewriter.Colors, len(header))
 	for i := range headersColors {
 		headersColors[i] = tablewriter.Colors{tablewriter.FgHiBlackColor}
 	}


### PR DESCRIPTION
Looks like in some refactoring that extracted pb mappings, some assignment got missed.

I also changed the `cmd.RenderTable` that we use in many commands to be safe if the underlying data of the table is empty:
```
panic: runtime error: index out of range [0] with length 0
goroutine 1 [running]:
github.com/textileio/textile/cmd.RenderTable(0xc00073dd10, 0x2, 0x2, 0x0, 0x0, 0x0)
	/home/runner/work/textile/textile/cmd/output.go:79 +0x336
```
I've seen in other parts that some commands check for `len(..) == 0` to avoid the `RenderTable` call, but I think is better to be on the safe side and don't panic in that case.