### PR TITLE
Remove call to powergate new addr

### DIFF
--- a/api/pow/client/client.go
+++ b/api/pow/client/client.go
@@ -60,15 +60,6 @@ func (c *Client) Addrs(ctx context.Context) (*ffsRpc.AddrsResponse, error) {
 	return c.ffsC.Addrs(ctx, &ffsRpc.AddrsRequest{})
 }
 
-func (c *Client) NewAddr(ctx context.Context, name, addrType string, makeDefault bool) (*ffsRpc.NewAddrResponse, error) {
-	req := &ffsRpc.NewAddrRequest{
-		Name:        name,
-		AddressType: addrType,
-		MakeDefault: makeDefault,
-	}
-	return c.ffsC.NewAddr(ctx, req)
-}
-
 func (c *Client) Info(ctx context.Context) (*ffsRpc.InfoResponse, error) {
 	return c.ffsC.Info(ctx, &ffsRpc.InfoRequest{})
 }

--- a/cmd/hub/cli/cli.go
+++ b/cmd/hub/cli/cli.go
@@ -50,7 +50,7 @@ func Init(rootCmd *cobra.Command) {
 	orgsCmd.AddCommand(orgsCreateCmd, orgsLsCmd, orgsMembersCmd, orgsInviteCmd, orgsLeaveCmd, orgsDestroyCmd)
 	keysCmd.AddCommand(keysCreateCmd, keysInvalidateCmd, keysLsCmd)
 	threadsCmd.AddCommand(threadsLsCmd)
-	powCmd.AddCommand(powAddrsCmd, powBalanceCmd, powConnectednessCmd, powFindPeerCmd, powHealthCmd, powInfoCmd, powNewAddrCmd, powPeersCmd, powRetrievalsCmd, powShowAllCmd, powShowCmd, powStorageCmd)
+	powCmd.AddCommand(powAddrsCmd, powBalanceCmd, powConnectednessCmd, powFindPeerCmd, powHealthCmd, powInfoCmd, powPeersCmd, powRetrievalsCmd, powShowAllCmd, powShowCmd, powStorageCmd)
 	rootCmd.AddCommand(bucketCmd)
 	buck.Init(bucketCmd)
 

--- a/cmd/hub/cli/pow.go
+++ b/cmd/hub/cli/pow.go
@@ -10,9 +10,6 @@ import (
 )
 
 func init() {
-	powNewAddrCmd.Flags().StringP("type", "t", "bls", "Wallet address type to create - bls or secp256k1. Defaults to bls.")
-	powNewAddrCmd.Flags().BoolP("default", "d", false, "Whether to make the new address the default. Defaults to false.")
-
 	powStorageCmd.Flags().BoolP("ascending", "a", false, "sort records ascending, default is sort descending")
 	powStorageCmd.Flags().StringSlice("cids", []string{}, "limit the records to deals for the specified data cids, treated as and AND operation if --addrs is also provided")
 	powStorageCmd.Flags().StringSlice("addrs", []string{}, "limit the records to deals initiated from  the specified wallet addresses, treated as and AND operation if --cids is also provided")
@@ -96,24 +93,6 @@ var powAddrsCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(Auth(context.Background()), cmd.Timeout)
 		defer cancel()
 		res, err := clients.Pow.Addrs(ctx)
-		cmd.ErrCheck(err)
-		cmd.Success("\n%v", proto.MarshalTextString(res))
-	},
-}
-
-var powNewAddrCmd = &cobra.Command{
-	Use:   "new-addr [name]",
-	Short: "Create a Filecoin wallet addresses associated with the current account or org",
-	Long:  `Create a Filecoin wallet addresses associated with the current account or org.`,
-	Args:  cobra.ExactArgs(1),
-	Run: func(c *cobra.Command, args []string) {
-		ctx, cancel := context.WithTimeout(Auth(context.Background()), cmd.Timeout)
-		defer cancel()
-		typ, err := c.Flags().GetString("type")
-		cmd.ErrCheck(err)
-		def, err := c.Flags().GetBool("default")
-		cmd.ErrCheck(err)
-		res, err := clients.Pow.NewAddr(ctx, args[0], typ, def)
 		cmd.ErrCheck(err)
 		cmd.Success("\n%v", proto.MarshalTextString(res))
 	},

--- a/core/core.go
+++ b/core/core.go
@@ -95,7 +95,6 @@ var (
 		},
 		ffsServiceName: {
 			"Addrs",
-			"NewAddr",
 			"Info",
 			"Show",
 			"ShowAll",

--- a/integrationtest/pg/pow_client_test.go
+++ b/integrationtest/pg/pow_client_test.go
@@ -60,12 +60,6 @@ func TestPowClient(t *testing.T) {
 		require.NotNil(t, res)
 	})
 
-	t.Run("NewAddr", func(t *testing.T) {
-		res, err := client.NewAddr(ctx, "new one", "bls", false)
-		require.NoError(t, err)
-		require.NotNil(t, res)
-	})
-
 	t.Run("Info", func(t *testing.T) {
 		res, err := client.Info(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
Disables the call in the interceptor level and then in the client and CLI as well.