### PR TITLE
Fix releases

### DIFF
--- a/.github/workflows/publish-js-libs.yml
+++ b/.github/workflows/publish-js-libs.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           go-version: 1.14
       - name: Setup env
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         run: |
           echo "::set-env name=GOPATH::$(go env GOPATH)"
           echo "::add-path::$(go env GOPATH)/bin"

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ build-buckd-release: $(GOX) $(GOVVV) $(GOMPLATE)
 .PHONY: build-buckd-release
 
 build-billingd-release: $(GOX) $(GOVVV) $(GOMPLATE)
-	$(call gen_release_files,./cmd/billingd,billingd,"linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64")
+	$(call gen_release_files,./api/billingd,billingd,"linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64")
 .PHONY: build-billingd-release
 
 build-releases: build-hub-release build-hubd-release build-buck-release build-buckd-release build-billingd-release


### PR DESCRIPTION
Github actions changed... can no longer use `set-env` or `add-path` commands without an env override. We'll want to upgrade to [the _new_ way](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) of doing this soon. Overriding for now.