### PR TITLE
Tmp fix for current period usage

### DIFF
--- a/api/billingd/client/client_test.go
+++ b/api/billingd/client/client_test.go
@@ -319,6 +319,7 @@ func setup(t *testing.T) *client.Client {
 		StripeAPIKey:           os.Getenv("STRIPE_API_KEY"),
 		StripeSessionReturnURL: "http://127.0.0.1:8006/dashboard",
 		SegmentAPIKey:          os.Getenv("SEGMENT_API_KEY"),
+		SegmentPrefix:          "test_",
 		DBURI:                  "mongodb://127.0.0.1:27017",
 		DBName:                 util.MakeToken(8),
 		GatewayHostAddr:        util.MustParseAddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", gwPort)),

--- a/api/billingd/gateway/gateway.go
+++ b/api/billingd/gateway/gateway.go
@@ -156,7 +156,7 @@ func (g *Gateway) webhookHandler(c *gin.Context) {
 		ctx, cancel := context.WithTimeout(context.Background(), handlerTimeout)
 		defer cancel()
 		if err := g.client.UpdateCustomer(ctx, cus.ID, cus.Balance, billable, cus.Delinquent); err != nil {
-			log.Errorf("updating customer: %v", err)
+			log.Warnf("updating customer: %v", err)
 			c.Status(http.StatusBadRequest)
 			return
 		}
@@ -181,7 +181,7 @@ func (g *Gateway) webhookHandler(c *gin.Context) {
 			sub.CurrentPeriodStart,
 			sub.CurrentPeriodEnd,
 		); err != nil {
-			log.Errorf("updating customer subscription: %v", err)
+			log.Warnf("updating customer subscription: %v", err)
 			c.Status(http.StatusBadRequest)
 			return
 		}

--- a/api/billingd/main.go
+++ b/api/billingd/main.go
@@ -64,13 +64,17 @@ var (
 				Key:      "stripe.webhook_secret",
 				DefValue: "",
 			},
-			"freeQuotaGracePeriod": {
-				Key:      "free_quota_grace_period",
-				DefValue: time.Hour * 24 * 7,
-			},
 			"segmentApiKey": {
 				Key:      "segment.api_key",
 				DefValue: "",
+			},
+			"segmentPrefix": {
+				Key:      "segment.prefix",
+				DefValue: "",
+			},
+			"freeQuotaGracePeriod": {
+				Key:      "free_quota_grace_period",
+				DefValue: time.Hour * 24 * 7,
 			},
 		},
 		EnvPre: "BILLING",
@@ -143,6 +147,10 @@ func init() {
 		"segmentApiKey",
 		config.Flags["segmentApiKey"].DefValue.(string),
 		"Segment API key")
+	rootCmd.PersistentFlags().String(
+		"segmentPrefix",
+		config.Flags["segmentPrefix"].DefValue.(string),
+		"Segment trait source prefix")
 
 	err := cmd.BindFlags(config.Viper, rootCmd, config.Flags)
 	cmd.ErrCheck(err)
@@ -186,6 +194,7 @@ var rootCmd = &cobra.Command{
 		freeQuotaGracePeriod := config.Viper.GetDuration("free_quota_grace_period")
 
 		segmentApiKey := config.Viper.GetString("segment.api_key")
+		segmentPrefix := config.Viper.GetString("segment.prefix")
 
 		logFile := config.Viper.GetString("log.file")
 		if logFile != "" {
@@ -202,6 +211,7 @@ var rootCmd = &cobra.Command{
 			StripeSessionReturnURL: stripeSessionReturnUrl,
 			StripeWebhookSecret:    stripeWebhookSecret,
 			SegmentAPIKey:          segmentApiKey,
+			SegmentPrefix:          segmentPrefix,
 			DBURI:                  addrMongoUri,
 			DBName:                 addrMongoName,
 			GatewayHostAddr:        addrGatewayHost,

--- a/api/bucketsd/client/client_test.go
+++ b/api/bucketsd/client/client_test.go
@@ -931,10 +931,12 @@ func setup(t *testing.T) (context.Context, *c.Client) {
 		StripeAPIURL:           "https://api.stripe.com",
 		StripeAPIKey:           os.Getenv("STRIPE_API_KEY"),
 		StripeSessionReturnURL: "http://127.0.0.1:8006/dashboard",
-		DBURI:           "mongodb://127.0.0.1:27017",
-		DBName:          util.MakeToken(8),
-		GatewayHostAddr: util.MustParseAddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", billingGwPort)),
-		Debug:           true,
+		SegmentAPIKey:          os.Getenv("SEGMENT_API_KEY"),
+		SegmentPrefix:          "test_",
+		DBURI:                  "mongodb://127.0.0.1:27017",
+		DBName:                 util.MakeToken(8),
+		GatewayHostAddr:        util.MustParseAddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", billingGwPort)),
+		Debug:                  true,
 	})
 	require.NoError(t, err)
 	err = api.Start()

--- a/api/hubd/client/client_test.go
+++ b/api/hubd/client/client_test.go
@@ -501,10 +501,12 @@ func setupWithBilling(t *testing.T) (core.Config, *c.Client, *tc.Client) {
 		StripeAPIURL:           "https://api.stripe.com",
 		StripeAPIKey:           os.Getenv("STRIPE_API_KEY"),
 		StripeSessionReturnURL: "http://127.0.0.1:8006/dashboard",
-		DBURI:           "mongodb://127.0.0.1:27017",
-		DBName:          util.MakeToken(8),
-		GatewayHostAddr: util.MustParseAddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", billingGwPort)),
-		Debug:           true,
+		SegmentAPIKey:          os.Getenv("SEGMENT_API_KEY"),
+		SegmentPrefix:          "test_",
+		DBURI:                  "mongodb://127.0.0.1:27017",
+		DBName:                 util.MakeToken(8),
+		GatewayHostAddr:        util.MustParseAddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", billingGwPort)),
+		Debug:                  true,
 	})
 	require.NoError(t, err)
 	err = api.Start()

--- a/api/usersd/client/client_test.go
+++ b/api/usersd/client/client_test.go
@@ -669,10 +669,12 @@ func setupWithBilling(t *testing.T) (core.Config, *c.Client, *hc.Client, *tc.Cli
 		StripeAPIURL:           "https://api.stripe.com",
 		StripeAPIKey:           os.Getenv("STRIPE_API_KEY"),
 		StripeSessionReturnURL: "http://127.0.0.1:8006/dashboard",
-		DBURI:           "mongodb://127.0.0.1:27017",
-		DBName:          util.MakeToken(8),
-		GatewayHostAddr: util.MustParseAddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", billingGwPort)),
-		Debug:           true,
+		SegmentAPIKey:          os.Getenv("SEGMENT_API_KEY"),
+		SegmentPrefix:          "test_",
+		DBURI:                  "mongodb://127.0.0.1:27017",
+		DBName:                 util.MakeToken(8),
+		GatewayHostAddr:        util.MustParseAddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", billingGwPort)),
+		Debug:                  true,
 	})
 	require.NoError(t, err)
 	err = api.Start()

--- a/core/usage_interceptor.go
+++ b/core/usage_interceptor.go
@@ -100,7 +100,7 @@ func (t *Textile) preUsageFunc(ctx context.Context, method string) (context.Cont
 	if err != nil {
 		if strings.Contains(err.Error(), mongo.ErrNoDocuments.Error()) {
 			opts := []billing.Option{
-				billing.WithEmail(account.Owner().Email),
+				billing.WithEmail(account.User.Email),
 			}
 			if account.Owner().Type == mdb.User {
 				key, ok := mdb.APIKeyFromContext(ctx)


### PR DESCRIPTION
Fix for a nit I noticed while testing on staging. Usage for monthly incremental products was not showing usage for the current day, only historical for the month. Was only noticeable across multiple days of usage, which my staging account has.