### PR TITLE
Fix Windows CLI problems

### DIFF
--- a/buckets/local/push.go
+++ b/buckets/local/push.go
@@ -44,7 +44,7 @@ func (b *Bucket) PushLocal(ctx context.Context, opts ...PathOption) (roots Roots
 			if err != nil {
 				return roots, err
 			}
-			p := strings.TrimPrefix(n, bp+"/")
+			p := strings.TrimPrefix(n, bp+string(os.PathSeparator))
 			reset = append(reset, Change{Type: dagutils.Add, Name: n, Path: p, Rel: r})
 		}
 		// Add unique additions

--- a/buckets/local/repo.go
+++ b/buckets/local/repo.go
@@ -15,7 +15,7 @@ import (
 	bserv "github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-ds-flatfs"
+	flatfs "github.com/ipfs/go-ds-flatfs"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	chunker "github.com/ipfs/go-ipfs-chunker"
 	dshelp "github.com/ipfs/go-ipfs-ds-help"
@@ -222,8 +222,8 @@ func (b *Repo) recursiveAddPath(ctx context.Context, pth string, dag ipld.DAGSer
 				return nil
 			}
 			p := n
-			n = strings.TrimPrefix(n, abs+"/")
-			if strings.HasPrefix(n, filepath.Dir(b.name)+"/") || strings.HasSuffix(n, patchExt) {
+			n = strings.TrimPrefix(n, abs+string(os.PathSeparator))
+			if strings.HasPrefix(n, filepath.Dir(b.name)+string(os.PathSeparator)) || strings.HasSuffix(n, patchExt) {
 				return nil
 			}
 			file, err := os.Open(p)
@@ -238,7 +238,7 @@ func (b *Repo) recursiveAddPath(ctx context.Context, pth string, dag ipld.DAGSer
 			if err = editor.InsertNodeAtPath(ctx, n, nd, unixfs.EmptyDirNode); err != nil {
 				return err
 			}
-			maps[strings.TrimPrefix(p, abs+"/")] = nd.Cid()
+			maps[strings.TrimPrefix(p, abs+string(os.PathSeparator))] = nd.Cid()
 		}
 		return nil
 	}); err != nil {

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -3,9 +3,10 @@ package cli
 import (
 	"context"
 	"os"
+	"runtime"
 	"strconv"
 
-	"github.com/logrusorgru/aurora"
+	aurora2 "github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/buckets/local"
@@ -17,9 +18,12 @@ const Name = "buck"
 
 var bucks *local.Buckets
 
+var aurora = aurora2.NewAurora(runtime.GOOS != "windows")
+
 func init() {
 	uiprogress.Empty = ' '
 	uiprogress.Fill = '-'
+
 }
 
 func Init(baseCmd *cobra.Command) {

--- a/cmd/buck/cli/init.go
+++ b/cmd/buck/cli/init.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	cid "github.com/ipfs/go-cid"
-	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/textileio/go-threads/core/thread"

--- a/cmd/buck/cli/pull.go
+++ b/cmd/buck/cli/pull.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/buckets/local"
 	"github.com/textileio/textile/v2/cmd"

--- a/cmd/buck/cli/push.go
+++ b/cmd/buck/cli/push.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/buckets"
 	"github.com/textileio/textile/v2/buckets/local"
@@ -62,7 +61,8 @@ var pushCmd = &cobra.Command{
 			ctx,
 			local.WithConfirm(getConfirm("Push %d changes", yes)),
 			local.WithForce(force),
-			local.WithPathEvents(events))
+			local.WithPathEvents(events),
+		)
 		if progress != nil {
 			progress.Stop()
 		}

--- a/cmd/buck/cli/roles.go
+++ b/cmd/buck/cli/roles.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/buckets"

--- a/cmd/buck/cli/util.go
+++ b/cmd/buck/cli/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	"github.com/ipfs/go-cid"
 	"github.com/manifoldco/promptui"
@@ -37,8 +38,15 @@ func handleProgressBars(p *uiprogress.Progress, events chan local.PathEvent) {
 	for e := range events {
 		switch e.Type {
 		case local.FileStart:
+			if runtime.GOOS == "windows" {
+				cmd.Message("Uploading %s", e.Path)
+				continue
+			}
 			bars[e.Path] = addBar(p, e.Path, e.Size)
 		case local.FileProgress, local.FileComplete:
+			if runtime.GOOS == "windows" {
+				continue
+			}
 			bar, ok := bars[e.Path]
 			if ok {
 				_ = bar.Set(int(e.Progress))
@@ -48,6 +56,10 @@ func handleProgressBars(p *uiprogress.Progress, events chan local.PathEvent) {
 				}
 			}
 		case local.FileRemoved:
+			if runtime.GOOS == "windows" {
+				cmd.Message("Removing %s", e.Path)
+				continue
+			}
 			bar := p.AddBar(int(e.Size))
 			finishBar(p, bar, e.Path, e.Cid, true)
 		}

--- a/cmd/buck/cli/watch.go
+++ b/cmd/buck/cli/watch.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/buckets/local"
 	"github.com/textileio/textile/v2/cmd"

--- a/cmd/hub/cli/billing.go
+++ b/cmd/hub/cli/billing.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/api/billingd/pb"
 	hub "github.com/textileio/textile/v2/api/hubd/client"

--- a/cmd/hub/cli/cli.go
+++ b/cmd/hub/cli/cli.go
@@ -3,9 +3,11 @@ package cli
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
+	aurora2 "github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/textileio/go-threads/core/thread"
@@ -15,6 +17,8 @@ import (
 )
 
 const Name = "hub"
+
+var aurora = aurora2.NewAurora(runtime.GOOS != "windows")
 
 var (
 	config = &cmd.Config{

--- a/cmd/hub/cli/destroy.go
+++ b/cmd/hub/cli/destroy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/cmd"

--- a/cmd/hub/cli/init.go
+++ b/cmd/hub/cli/init.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/caarlos0/spin"
-	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/cmd"

--- a/cmd/hub/cli/keys.go
+++ b/cmd/hub/cli/keys.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	pb "github.com/textileio/textile/v2/api/hubd/pb"

--- a/cmd/hub/cli/login.go
+++ b/cmd/hub/cli/login.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/caarlos0/spin"
-	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/cmd"

--- a/cmd/hub/cli/orgs.go
+++ b/cmd/hub/cli/orgs.go
@@ -6,7 +6,6 @@ import (
 	"net/mail"
 	"strconv"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/manifoldco/promptui"
 	mbase "github.com/multiformats/go-multibase"
 	"github.com/spf13/cobra"

--- a/cmd/hub/cli/threads.go
+++ b/cmd/hub/cli/threads.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/cmd"
 )

--- a/cmd/hub/cli/update.go
+++ b/cmd/hub/cli/update.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/caarlos0/spin"
-	"github.com/logrusorgru/aurora"
 	su "github.com/rhysd/go-github-selfupdate/selfupdate"
 	"github.com/spf13/cobra"
 	bi "github.com/textileio/textile/v2/buildinfo"

--- a/cmd/hub/cli/version.go
+++ b/cmd/hub/cli/version.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/caarlos0/spin"
-	"github.com/logrusorgru/aurora"
 	su "github.com/rhysd/go-github-selfupdate/selfupdate"
 	"github.com/spf13/cobra"
 	bi "github.com/textileio/textile/v2/buildinfo"

--- a/cmd/hub/cli/whoami.go
+++ b/cmd/hub/cli/whoami.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 
-	"github.com/logrusorgru/aurora"
 	mbase "github.com/multiformats/go-multibase"
 	"github.com/spf13/cobra"
 	"github.com/textileio/textile/v2/cmd"

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -4,14 +4,17 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 
-	"github.com/logrusorgru/aurora"
+	aurora2 "github.com/logrusorgru/aurora"
 	"github.com/olekukonko/tablewriter"
 	"github.com/textileio/textile/v2/api/billingd/common"
 	"github.com/textileio/textile/v2/api/bucketsd"
 	"google.golang.org/grpc/status"
 )
+
+var aurora = aurora2.NewAurora(runtime.GOOS != "windows")
 
 func Message(format string, args ...interface{}) {
 	if format == "" {


### PR DESCRIPTION
This fixes multiples Hub CLI problems in Windows. 
There were three main problems:
- We had an assumption of `/` being the path separator, which is now changed to `runtime.OsPathSeparator` to be platform-independent.
- The `uiprogress` component used in pushing files doesn't work in Windows, it tries to use `stty` with error: `←[31m> Error! ←[90mExec: "stty": executable file not found in %!P(MISSING)ATH%!←(MISSING)[0m←[0m`. I changed to detect if that's the case and avoid using the component but explain the event with plain text. (see screenshot below).
- The Windows terminal doesn't support ANSI colors as explained in the `aurora` package we use for coloring terminal output. I changed the `aurora` reference to a custom instance which enables or disables coloring depending on the OS.

Before it printed ANSI Colors characters which were very confusing for UX, like:
`←[31m> Error! ←[90mSome errors or similar←[0m←[0m`

Example of how it looks now:
![image](https://user-images.githubusercontent.com/6136245/100745020-6f0eab80-33bd-11eb-9b42-a49a2135ac5c.png)
So there you can see:
- No ANSI color characters in outputs.
- Progress bars changed to plaintext explanation of the event.
- `.textile` folder is ignored as expected, and #428 is fixed.

Fixes #428 