### PR TITLE
Prerelease to NPM

### DIFF
--- a/.github/workflows/publish-js-libs.yml
+++ b/.github/workflows/publish-js-libs.yml
@@ -9,11 +9,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v1
-      - name: Get latest tag
-        id: latesttag
-        uses: "WyriHaximus/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Install build tools
         run: |
           sudo apt-get update
@@ -31,11 +26,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
       - name: Generate JS libs
         run: |
           make js-protos
       - name: Publish JS libs
         run: |
-          ./scripts/publish_js_protos.bash -v ${{ steps.latesttag.outputs.tag }} -t ${{ secrets.NPM_AUTH_TOKEN }}
+          ./scripts/publish_js_protos.bash -v ${{ github.event.release.tag_name }} -t ${{ secrets.NPM_AUTH_TOKEN }} -p ${{ github.event.release.prerelease }}

--- a/scripts/publish_js_protos.bash
+++ b/scripts/publish_js_protos.bash
@@ -1,12 +1,20 @@
 #!/bin/bash
 set -eo pipefail
 
-while getopts v:t: option
+tag="latest"
+
+while getopts v:t:p: option
 do
 case "${option}"
 in
 v) version=${OPTARG};;
 t) token=${OPTARG};;
+p)
+  if [[ "$OPTARG" == "true" ]]; 
+  then
+    tag="next"
+  fi
+  ;;
 esac
 done
 
@@ -27,7 +35,7 @@ for path in "${js_paths[@]}"; do
   cd "${path}"
   json -I -f package.json -e "this.version=('$version').replace('v', '')" >/dev/null 2>&1
   echo publishing js-protos in "${path}" with version "${version}" and token "${token}"
-  NODE_AUTH_TOKEN="${token}" npm publish --access=public
+  NODE_AUTH_TOKEN="${token}" npm publish --access=public --tag ${tag}
   json -I -f package.json -e "this.version=('0.0.0')" >/dev/null 2>&1
   cd "${wd}"
 done


### PR DESCRIPTION
It would be nice to do prereleases in GitHub and publish NPM artifacts to the `next` tag instead of overriding the `latest` tag. These changes should enable that.