### PR TITLE
go-threads v1.0.2

### DIFF
--- a/api/billingd/gateway/gateway.go
+++ b/api/billingd/gateway/gateway.go
@@ -157,7 +157,7 @@ func (g *Gateway) webhookHandler(c *gin.Context) {
 		defer cancel()
 		if err := g.client.UpdateCustomer(ctx, cus.ID, cus.Balance, billable, cus.Delinquent); err != nil {
 			log.Warnf("updating customer: %v", err)
-			c.Status(http.StatusBadRequest)
+			c.Status(http.StatusOK)
 			return
 		}
 		log.Debugf("%s was updated", cus.ID)
@@ -182,7 +182,7 @@ func (g *Gateway) webhookHandler(c *gin.Context) {
 			sub.CurrentPeriodEnd,
 		); err != nil {
 			log.Warnf("updating customer subscription: %v", err)
-			c.Status(http.StatusBadRequest)
+			c.Status(http.StatusOK)
 			return
 		}
 		log.Debugf("%s subscription was updated", sub.ID)

--- a/cmd/buckd/docker-compose-dev.yml
+++ b/cmd/buckd/docker-compose-dev.yml
@@ -5,16 +5,18 @@ services:
       context: ../../
       dockerfile: ./cmd/buckd/Dockerfile
     environment:
+      - BUCK_LOG_DEBUG=true
+      - BUCK_LOG_FILE
       - BUCK_ADDR_API=/ip4/0.0.0.0/tcp/3006
       - BUCK_ADDR_API_PROXY=/ip4/0.0.0.0/tcp/3007
+      - BUCK_ADDR_MONGO_URI=mongodb://mongo:27017
+      - BUCK_ADDR_MONGO_NAME
       - BUCK_ADDR_THREADS_HOST=/ip4/0.0.0.0/tcp/4006
       - BUCK_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8006
-      - BUCK_ADDR_MONGO_URI=mongodb://mongo:27017
+      - BUCK_ADDR_GATEWAY_URL
       - BUCK_ADDR_IPFS_API=/dns4/ipfs/tcp/5001
       - BUCK_ADDR_POWERGATE_API
       - BUCK_GATEWAY_SUBDOMAINS
-      - BUCK_LOG_DEBUG=true
-      - BUCK_LOG_FILE
     ports:
       - "127.0.0.1:3006:3006"
       - "3007:3007"

--- a/cmd/buckd/docker-compose.yml
+++ b/cmd/buckd/docker-compose.yml
@@ -6,20 +6,21 @@ services:
     volumes:
       - "${REPO_PATH}/buckets:/data/buckets"
     environment:
+      - BUCK_LOG_DEBUG
+      - BUCK_LOG_FILE
       - BUCK_ADDR_API=/ip4/0.0.0.0/tcp/3006
       - BUCK_ADDR_API_PROXY=/ip4/0.0.0.0/tcp/3007
+      - BUCK_ADDR_MONGO_URI=mongodb://mongo:27017
+      - BUCK_ADDR_MONGO_NAME
       - BUCK_ADDR_THREADS_HOST=/ip4/0.0.0.0/tcp/4006
       - BUCK_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8006
       - BUCK_ADDR_GATEWAY_URL
-      - BUCK_ADDR_MONGO_URI=mongodb://mongo:27017
       - BUCK_ADDR_IPFS_API=/dns4/ipfs/tcp/5001
       - BUCK_ADDR_POWERGATE_API
       - BUCK_GATEWAY_SUBDOMAINS
       - BUCK_DNS_DOMAIN
       - BUCK_DNS_ZONE_ID
       - BUCK_DNS_TOKEN
-      - BUCK_LOG_DEBUG
-      - BUCK_LOG_FILE
     ports:
       - "127.0.0.1:3006:3006"
       - "3007:3007"

--- a/cmd/hubd/docker-compose-dev.yml
+++ b/cmd/hubd/docker-compose-dev.yml
@@ -5,26 +5,45 @@ services:
       context: ../../
       dockerfile: ./cmd/hubd/Dockerfile
     environment:
+      - HUB_LOG_DEBUG=true
+      - HUB_LOG_FILE
       - HUB_ADDR_API=/ip4/0.0.0.0/tcp/3006
       - HUB_ADDR_API_PROXY=/ip4/0.0.0.0/tcp/3007
+      - HUB_ADDR_MONGO_URI=mongodb://mongo:27017
+      - HUB_ADDR_MONGO_NAME
       - HUB_ADDR_THREADS_HOST=/ip4/0.0.0.0/tcp/4006
       - HUB_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8006
-      - HUB_ADDR_MONGO_URI=mongodb://mongo:27017
+      - HUB_ADDR_GATEWAY_URL
       - HUB_ADDR_IPFS_API=/dns4/ipfs/tcp/5001
+      - HUB_ADDR_BILLING_API=billing:10006
       - HUB_ADDR_POWERGATE_API
       - HUB_GATEWAY_SUBDOMAINS
       - HUB_EMAIL_SESSION_SECRET=hubsession
       - HUB_BUCKETS_MAX_SIZE
-      - HUB_BUCKETS_MAX_NUMBER_PER_THREAD
-      - HUB_BUCKETS_TOTAL_MAX_SIZE
       - HUB_THREADS_MAX_NUMBER_PER_OWNER
-      - HUB_LOG_DEBUG=true
-      - HUB_LOG_FILE
     ports:
       - "127.0.0.1:3006:3006"
       - "3007:3007"
       - "4006:4006"
       - "127.0.0.1:8006:8006"
+  billing:
+    build:
+      context: ../../
+      dockerfile: ./api/billingd/Dockerfile
+    environment:
+      - BILLING_LOG_DEBUG=true
+      - BILLING_LOG_FILE
+      - BILLING_ADDR_API=/ip4/0.0.0.0/tcp/10006
+      - BILLING_ADDR_MONGO_URI=mongodb://mongo:27017
+      - BILLING_ADDR_MONGO_NAME
+      - BILLING_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8010
+      - BILLING_ADDR_GATEWAY_URL
+      - BILLING_STRIPE_API_KEY
+      - BILLING_SEGMENT_API_KEY
+      - BILLING_SEGMENT_PREFIX
+    ports:
+      - "127.0.0.1:10006:10006"
+      - "127.0.0.1:8010:8010"
   mongo:
     image: mongo:latest
     ports:

--- a/cmd/hubd/docker-compose.yml
+++ b/cmd/hubd/docker-compose.yml
@@ -6,30 +6,47 @@ services:
     volumes:
       - "${REPO_PATH}/textile:/data/textile"
     environment:
+      - HUB_LOG_DEBUG
+      - HUB_LOG_FILE
       - HUB_ADDR_API=/ip4/0.0.0.0/tcp/3006
       - HUB_ADDR_API_PROXY=/ip4/0.0.0.0/tcp/3007
+      - HUB_ADDR_MONGO_URI=mongodb://mongo:27017
+      - HUB_ADDR_MONGO_NAME
       - HUB_ADDR_THREADS_HOST=/ip4/0.0.0.0/tcp/4006
       - HUB_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8006
       - HUB_ADDR_GATEWAY_URL
-      - HUB_ADDR_MONGO_URI=mongodb://mongo:27017
       - HUB_ADDR_IPFS_API=/dns4/ipfs/tcp/5001
+      - HUB_ADDR_BILLING_API=billing:10006
       - HUB_ADDR_POWERGATE_API
       - HUB_GATEWAY_SUBDOMAINS
       - HUB_EMAIL_API_KEY
       - HUB_DNS_DOMAIN
       - HUB_DNS_ZONE_ID
       - HUB_DNS_TOKEN
-      - HUB_BUCKETS_MAX_SIZE=1073741824
-      - HUB_BUCKETS_TOTAL_MAX_SIZE=1073741824
-      - HUB_BUCKETS_MAX_NUMBER_PER_THREAD=10000
-      - HUB_THREADS_MAX_NUMBER_PER_OWNER=100
-      - HUB_LOG_DEBUG
-      - HUB_LOG_FILE
+      - HUB_BUCKETS_MAX_SIZE
+      - HUB_THREADS_MAX_NUMBER_PER_OWNER
     ports:
       - "127.0.0.1:3006:3006"
       - "3007:3007"
       - "4006:4006"
       - "127.0.0.1:8006:8006"
+  billing:
+    image: textile/textile:billing
+    restart: always
+    environment:
+      - BILLING_LOG_DEBUG
+      - BILLING_LOG_FILE
+      - BILLING_ADDR_API=/ip4/0.0.0.0/tcp/10006
+      - BILLING_ADDR_MONGO_URI=mongodb://mongo:27017
+      - BILLING_ADDR_MONGO_NAME
+      - BILLING_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8010
+      - BILLING_ADDR_GATEWAY_URL
+      - BILLING_STRIPE_API_KEY
+      - BILLING_SEGMENT_API_KEY
+      - BILLING_SEGMENT_PREFIX
+    ports:
+      - "127.0.0.1:10006:10006"
+      - "127.0.0.1:8010:8010"
   mongo:
     image: mongo:latest
     restart: always

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/stripe/stripe-go/v72 v72.10.0
 	github.com/textileio/dcrypto v0.0.1
 	github.com/textileio/go-assets v0.0.0-20200430191519-b341e634e2b7
-	github.com/textileio/go-threads v1.0.1
+	github.com/textileio/go-threads v1.0.2
 	github.com/textileio/powergate v1.2.1
 	github.com/textileio/uiprogress v0.0.4
 	github.com/xakep666/mongo-migrate v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1526,8 +1526,8 @@ github.com/textileio/go-ds-badger v0.2.5-0.20200819232634-de89720b5d6a h1:AdjNdw
 github.com/textileio/go-ds-badger v0.2.5-0.20200819232634-de89720b5d6a/go.mod h1:0kLVpG7eeM95s4rS78lQe4eG5DCk+cnU8xas2nPSdZY=
 github.com/textileio/go-ds-mongo v0.1.2 h1:sL7wFBfETdn18lmLqc7wVOFcn9Yy7lqNqFqQQAeB6hU=
 github.com/textileio/go-ds-mongo v0.1.2/go.mod h1:9wmGTUr+MWidGxYQe27RuCogEUZ7vnQxZb4GWj7uWL8=
-github.com/textileio/go-threads v1.0.1 h1:Hoa8fv7YnZrsSF244cTF3C+unP9lQh43mZFEB/UHyzI=
-github.com/textileio/go-threads v1.0.1/go.mod h1:6ZQAr1DHFT8MsmLzGqlko4nZzY70osOK4e+zoU1ssiI=
+github.com/textileio/go-threads v1.0.2 h1:iYUA/E9gx9ALpYNYSCwKGhV3yOjxf6QtLliRitnsFSk=
+github.com/textileio/go-threads v1.0.2/go.mod h1:6ZQAr1DHFT8MsmLzGqlko4nZzY70osOK4e+zoU1ssiI=
 github.com/textileio/powergate v1.2.1 h1:qMqSo/nqN870NRCSrH5AqIQhPm/v9V1HHAiZrFWy5AM=
 github.com/textileio/powergate v1.2.1/go.mod h1:MFWG3Tm4wv/Sb5fIL+JyM7mDbvZtfdh8ky09VJFnGNg=
 github.com/textileio/uiprogress v0.0.4 h1:7FWXEKK/h54ssNOW24q9MeJ9Eujptsr8eDPq35aPHjo=


### PR DESCRIPTION
- Updates `go-threads` to v1.0.2
- Since we're using real Stripe keys for staging and production, events from either env are received by both. This doesn't hurt anything, but it does mean that the webhook thinks it's unhealthy and is threatening to delete it. So, if the event fails our biz logic, we just log a warning and return 200. I'd like to create a different stripe account for staging so we can use _different_ live keys there. Then we can revert this change. 