### PR TITLE
Add Filecoin wallet sign and verify methods

### DIFF
--- a/api/filecoin/client/client.go
+++ b/api/filecoin/client/client.go
@@ -36,6 +36,19 @@ func (c *Client) Balance(ctx context.Context, addr string) (*userPb.BalanceRespo
 	return c.powC.Balance(ctx, req)
 }
 
+func (c *Client) SignMessage(ctx context.Context, address string, message []byte) (*userPb.SignMessageResponse, error) {
+	req := &userPb.SignMessageRequest{
+		Address: address,
+		Message: message,
+	}
+	return c.powC.SignMessage(ctx, req)
+}
+
+func (c *Client) VerifyMessage(ctx context.Context, address string, message, signature []byte) (*userPb.VerifyMessageResponse, error) {
+	r := &userPb.VerifyMessageRequest{Address: address, Message: message, Signature: signature}
+	return c.powC.VerifyMessage(ctx, r)
+}
+
 func (c *Client) CidInfo(ctx context.Context, cids ...string) (*userPb.CidInfoResponse, error) {
 	req := &userPb.CidInfoRequest{Cids: cids}
 	return c.powC.CidInfo(ctx, req)

--- a/cmd/hub/cli/cli.go
+++ b/cmd/hub/cli/cli.go
@@ -71,7 +71,7 @@ func Init(rootCmd *cobra.Command) {
 	orgsCmd.AddCommand(orgsCreateCmd, orgsLsCmd, orgsMembersCmd, orgsInviteCmd, orgsLeaveCmd, orgsDestroyCmd)
 	keysCmd.AddCommand(keysCreateCmd, keysInvalidateCmd, keysLsCmd)
 	threadsCmd.AddCommand(threadsLsCmd)
-	filCmd.AddCommand(filAddrsCmd, filBalanceCmd, filInfoCmd, filStorageCmd, filRetrievalsCmd)
+	filCmd.AddCommand(filAddrsCmd, filBalanceCmd, filSignCmd, filVerifyCmd, filInfoCmd, filStorageCmd, filRetrievalsCmd)
 	billingCmd.AddCommand(billingSetupCmd, billingPortalCmd, billingUsageCmd, billingUsersCmd)
 	rootCmd.AddCommand(bucketCmd)
 	buck.Init(bucketCmd)

--- a/core/core.go
+++ b/core/core.go
@@ -85,6 +85,8 @@ var (
 		powergateServiceName: {
 			"Addresses",
 			"Balance",
+			"SignMessage",
+			"VerifyMessage",
 			"CidInfo",
 			"StorageDealRecords",
 			"RetrievalDealRecords",


### PR DESCRIPTION
Allows Slingshot participants using Hub bucket archives to sign messages for the competition. 

Closes #422 