### PR TITLE
billing: avoid empty customer string

### DIFF
--- a/api/billingd/client/client_test.go
+++ b/api/billingd/client/client_test.go
@@ -42,6 +42,9 @@ func TestClient_CreateCustomer(t *testing.T) {
 	_, err := c.CreateCustomer(context.Background(), key, email, mdb.Dev)
 	require.NoError(t, err)
 
+	_, err = c.CreateCustomer(context.Background(), key, email, mdb.Dev)
+	require.Error(t, err)
+
 	_, err = c.CreateCustomer(
 		context.Background(),
 		newKey(t),

--- a/api/billingd/service/service.go
+++ b/api/billingd/service/service.go
@@ -482,10 +482,10 @@ func (s *Service) createCustomer(
 		AccountType: mdb.AccountType(params.AccountType),
 		CreatedAt:   time.Now().Unix(),
 	}
-	if _, err := s.cdb.InsertOne(ctx, doc); err != nil {
+	if err := s.createSubscription(doc); err != nil {
 		return nil, err
 	}
-	if err := s.createSubscription(doc); err != nil {
+	if _, err := s.cdb.InsertOne(ctx, doc); err != nil {
 		return nil, err
 	}
 	log.Debugf("created customer %s with id %s", doc.Key, doc.CustomerID)

--- a/buckets/local/buckets_test.go
+++ b/buckets/local/buckets_test.go
@@ -329,7 +329,7 @@ func (c *eventCollector) collect(events chan PathEvent) {
 }
 
 func (c *eventCollector) check(t *testing.T, numFilesAdded, numFilesRemoved int) {
-	time.Sleep(time.Second)
+	time.Sleep(5 * time.Second)
 	c.Lock()
 	defer c.Unlock()
 	if numFilesAdded > 0 {

--- a/mail/local/mailbox_test.go
+++ b/mail/local/mailbox_test.go
@@ -139,7 +139,7 @@ func (c *eventCollector) collect(events chan MailboxEvent) {
 }
 
 func (c *eventCollector) check(t *testing.T, numNew, numRead, numDeleted int) {
-	time.Sleep(time.Second)
+	time.Sleep(5 * time.Second)
 	c.Lock()
 	defer c.Unlock()
 	assert.Equal(t, numNew, c.new)


### PR DESCRIPTION
Of course, an empty string is not considered "sparse" in a document... a downside of using Go structs with the mongo API: No way to omit a string field.