### PR TITLE
Update docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Made by Textile](https://img.shields.io/badge/made%20by-Textile-informational.svg?style=popout-square)](https://textile.io)
 [![Chat on Slack](https://img.shields.io/badge/slack-slack.textile.io-informational.svg?style=popout-square)](https://slack.textile.io)
 [![GitHub license](https://img.shields.io/github/license/textileio/textile.svg?style=popout-square)](./LICENSE)
-[![Go Report Card](https://goreportcard.com/badge/github.com/textileio/textile?style=flat-square)](https://goreportcard.com/report/github.com/textileio/textile?style=flat-square)
 [![GitHub action](https://github.com/textileio/textile/workflows/Tests/badge.svg?style=popout-square)](https://github.com/textileio/textile/actions)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=popout-square)](https://github.com/RichardLitt/standard-readme)
 

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -3,8 +3,7 @@ package analytics
 import (
 	"time"
 
-	logging "github.com/ipfs/go-log"
-	"gopkg.in/segmentio/analytics-go.v3"
+	logging "github.com/ipfs/go-log/v2"
 	segment "gopkg.in/segmentio/analytics-go.v3"
 )
 
@@ -42,7 +41,7 @@ func NewClient(segmentAPIKey, prefix string, debug bool) (*Client, error) {
 // Update updates the user metadata
 func (c *Client) Update(userID, email string, active bool, properties map[string]interface{}) {
 	if c.api != nil && email != "" {
-		traits := analytics.NewTraits()
+		traits := segment.NewTraits()
 		traits.SetEmail(email)
 		for key, value := range properties {
 			traits.Set(key, value)
@@ -51,7 +50,7 @@ func (c *Client) Update(userID, email string, active bool, properties map[string
 		if err := c.api.Enqueue(segment.Identify{
 			UserId: userID,
 			Traits: traits,
-			Context: &analytics.Context{
+			Context: &segment.Context{
 				Extra: map[string]interface{}{
 					"active": active,
 				},
@@ -65,7 +64,7 @@ func (c *Client) Update(userID, email string, active bool, properties map[string
 // NewEvent logs a new event
 func (c *Client) NewEvent(userID, email, eventName string, active bool, properties map[string]interface{}) {
 	if c.api != nil && email != "" {
-		props := analytics.NewProperties()
+		props := segment.NewProperties()
 		for key, value := range properties {
 			props.Set(key, value)
 		}
@@ -74,7 +73,7 @@ func (c *Client) NewEvent(userID, email, eventName string, active bool, properti
 			UserId:     userID,
 			Event:      eventName,
 			Properties: props,
-			Context: &analytics.Context{
+			Context: &segment.Context{
 				Extra: map[string]interface{}{
 					"active": active,
 				},

--- a/api/billingd/Dockerfile
+++ b/api/billingd/Dockerfile
@@ -4,24 +4,11 @@ MAINTAINER Textile <contact@textile.io>
 # This is (in large part) copied (with love) from
 # https://hub.docker.com/r/ipfs/go-ipfs/dockerfile
 
-# Get the TLS CA certificates, they're not provided by busybox.
-RUN apt-get update && apt-get install -y ca-certificates
+# Install deps
+RUN apt-get update && apt-get install -y \
+  libssl-dev \
+  ca-certificates
 
-# Get su-exec, a very minimal tool for dropping privileges,
-# and tini, a very minimal init daemon for containers
-ENV SUEXEC_VERSION v0.2
-ENV TINI_VERSION v0.16.1
-RUN set -x \
-  && cd /tmp \
-  && git clone https://github.com/ncopa/su-exec.git \
-  && cd su-exec \
-  && git checkout -q $SUEXEC_VERSION \
-  && make \
-  && cd /tmp \
-  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
-  && chmod +x tini
-
-# Get source
 ENV SRC_DIR /textile
 
 # Download packages first so they can be cached.
@@ -31,28 +18,59 @@ RUN cd $SRC_DIR \
 
 COPY . $SRC_DIR
 
-# Install the daemon
-RUN cd $SRC_DIR && TXTL_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-billingd
+# Build the thing.
+RUN cd $SRC_DIR \
+  && TXTL_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-billingd
+
+# Get su-exec, a very minimal tool for dropping privileges,
+# and tini, a very minimal init daemon for containers
+ENV SUEXEC_VERSION v0.2
+ENV TINI_VERSION v0.19.0
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        "amd64" | "armhf" | "arm64") tiniArch="tini-static-$dpkgArch" ;;\
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+  cd /tmp \
+  && git clone https://github.com/ncopa/su-exec.git \
+  && cd su-exec \
+  && git checkout -q $SUEXEC_VERSION \
+  && make su-exec-static \
+  && cd /tmp \
+  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/$tiniArch \
+  && chmod +x tini
 
 # Now comes the actual target image, which aims to be as small as possible.
-FROM busybox:1.31.0-glibc
+FROM busybox:1.31.1-glibc
 LABEL maintainer="Textile <contact@textile.io>"
 
 # Get the textile binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /textile
-COPY --from=0 /textile/billingd /usr/local/bin/billingd
-COPY --from=0 /tmp/su-exec/su-exec /sbin/su-exec
+COPY --from=0 $SRC_DIR/billingd /usr/local/bin/billingd
+COPY --from=0 /tmp/su-exec/su-exec-static /sbin/su-exec
 COPY --from=0 /tmp/tini /sbin/tini
 COPY --from=0 /etc/ssl/certs /etc/ssl/certs
 
 # This shared lib (part of glibc) doesn't seem to be included with busybox.
-COPY --from=0 /lib/x86_64-linux-gnu/libdl.so.2 /lib/libdl.so.2
+COPY --from=0 /lib/*-linux-gnu*/libdl.so.2 /lib/
 
-# addrApi; should be exposed to the public
+# Copy over SSL libraries.
+COPY --from=0 /usr/lib/*-linux-gnu*/libssl.so* /usr/lib/
+COPY --from=0 /usr/lib/*-linux-gnu*/libcrypto.so* /usr/lib/
+
+# addrApi; can be exposed to the public
 EXPOSE 10006
+# addrGatewayHost; can be exposed to the public.
+EXPOSE 8010
+
+# Create the repo directory.
+ENV BILLING_PATH /data/billing
+RUN mkdir -p $BILLING_PATH \
+  && adduser -D -h $BILLING_PATH -u 1000 -G users billing \
+  && chown billing:users $BILLING_PATH
 
 # Switch to a non-privileged user.
-RUN addgroup textile && adduser -D -G textile textile
-USER textile
+USER billing
 
 ENTRYPOINT ["/sbin/tini", "--", "billingd"]

--- a/api/billingd/Dockerfile.dev
+++ b/api/billingd/Dockerfile.dev
@@ -1,0 +1,33 @@
+FROM golang:1.15.5-buster
+
+RUN apt-get update
+
+RUN go get github.com/go-delve/delve/cmd/dlv
+
+ENV SRC_DIR /textile
+
+COPY go.mod go.sum $SRC_DIR/
+RUN cd $SRC_DIR \
+  && go mod download
+
+COPY . $SRC_DIR
+
+RUN cd $SRC_DIR \
+  && CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -o billingd api/billingd/main.go
+
+FROM debian:buster
+LABEL maintainer="Textile <contact@textile.io>"
+
+ENV SRC_DIR /textile
+COPY --from=0 /go/bin/dlv /usr/local/bin/dlv
+COPY --from=0 /textile/billingd /usr/local/bin/billingd
+
+EXPOSE 10006
+EXPOSE 8010
+
+ENV BILLING_PATH /data/billing
+RUN adduser --home $BILLING_PATH --disabled-login --gecos "" --ingroup users billing
+
+USER billing
+
+ENTRYPOINT ["dlv", "--listen=0.0.0.0:40000", "--headless=true", "--accept-multiclient", "--continue", "--api-version=2", "exec", "/usr/local/bin/billingd"]

--- a/api/billingd/Dockerfile.dev
+++ b/api/billingd/Dockerfile.dev
@@ -20,7 +20,7 @@ LABEL maintainer="Textile <contact@textile.io>"
 
 ENV SRC_DIR /textile
 COPY --from=0 /go/bin/dlv /usr/local/bin/dlv
-COPY --from=0 /textile/billingd /usr/local/bin/billingd
+COPY --from=0 $SRC_DIR/billingd /usr/local/bin/billingd
 
 EXPOSE 10006
 EXPOSE 8010

--- a/api/billingd/gateway/gateway.go
+++ b/api/billingd/gateway/gateway.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	ma "github.com/multiformats/go-multiaddr"
 	stripe "github.com/stripe/stripe-go/v72"
 	"github.com/stripe/stripe-go/v72/webhook"

--- a/api/billingd/main.go
+++ b/api/billingd/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/textileio/go-threads/util"
@@ -30,7 +30,7 @@ var (
 			},
 			"logFile": {
 				Key:      "log.file",
-				DefValue: "${HOME}/." + daemonName + "/log",
+				DefValue: "", // no log file
 			},
 			"addrApi": {
 				Key:      "addr.api",
@@ -198,7 +198,7 @@ var rootCmd = &cobra.Command{
 
 		logFile := config.Viper.GetString("log.file")
 		if logFile != "" {
-			err = util.SetupDefaultLoggingConfig(logFile)
+			err = cmd.SetupDefaultLoggingConfig(logFile)
 			cmd.ErrCheck(err)
 		}
 

--- a/api/billingd/migrations/migrations.go
+++ b/api/billingd/migrations/migrations.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	migrate "github.com/xakep666/mongo-migrate"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"

--- a/api/billingd/service/service.go
+++ b/api/billingd/service/service.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	ma "github.com/multiformats/go-multiaddr"
 	cron "github.com/robfig/cron/v3"
 	stripe "github.com/stripe/stripe-go/v72"

--- a/api/bucketsd/service.go
+++ b/api/bucketsd/service.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ipfs/go-cid"
 	ipfsfiles "github.com/ipfs/go-ipfs-files"
 	ipld "github.com/ipfs/go-ipld-format"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	dag "github.com/ipfs/go-merkledag"
 	"github.com/ipfs/go-unixfs"
 	iface "github.com/ipfs/interface-go-ipfs-core"

--- a/api/hubd/service.go
+++ b/api/hubd/service.go
@@ -7,7 +7,7 @@ import (
 	"net/mail"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	"github.com/ipfs/interface-go-ipfs-core/path"
 	threads "github.com/textileio/go-threads/api/client"

--- a/api/usersd/service.go
+++ b/api/usersd/service.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	ulid "github.com/oklog/ulid/v2"
 	coredb "github.com/textileio/go-threads/core/db"
 	"github.com/textileio/go-threads/core/thread"

--- a/buckets/archive/tracker.go
+++ b/buckets/archive/tracker.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/ipfs/go-cid"
-	logger "github.com/ipfs/go-log"
+	logger "github.com/ipfs/go-log/v2"
 	"github.com/textileio/go-threads/core/thread"
 	powc "github.com/textileio/powergate/api/client"
 	userPb "github.com/textileio/powergate/api/gen/powergate/user/v1"

--- a/cmd/buckd/Dockerfile
+++ b/cmd/buckd/Dockerfile
@@ -4,24 +4,11 @@ MAINTAINER Textile <contact@textile.io>
 # This is (in large part) copied (with love) from
 # https://hub.docker.com/r/ipfs/go-ipfs/dockerfile
 
-# Get the TLS CA certificates, they're not provided by busybox.
-RUN apt-get update && apt-get install -y ca-certificates
+# Install deps
+RUN apt-get update && apt-get install -y \
+  libssl-dev \
+  ca-certificates
 
-# Get su-exec, a very minimal tool for dropping privileges,
-# and tini, a very minimal init daemon for containers
-ENV SUEXEC_VERSION v0.2
-ENV TINI_VERSION v0.16.1
-RUN set -x \
-  && cd /tmp \
-  && git clone https://github.com/ncopa/su-exec.git \
-  && cd su-exec \
-  && git checkout -q $SUEXEC_VERSION \
-  && make \
-  && cd /tmp \
-  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
-  && chmod +x tini
-
-# Get source
 ENV SRC_DIR /textile
 
 # Download packages first so they can be cached.
@@ -31,47 +18,67 @@ RUN cd $SRC_DIR \
 
 COPY . $SRC_DIR
 
-# Install the daemon
+# Build the thing.
 RUN cd $SRC_DIR \
-  && CGO_ENABLED=0 GOOS=linux go build -o buckd cmd/buckd/main.go
+  && TXTL_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-buckd
+
+# Get su-exec, a very minimal tool for dropping privileges,
+# and tini, a very minimal init daemon for containers
+ENV SUEXEC_VERSION v0.2
+ENV TINI_VERSION v0.19.0
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        "amd64" | "armhf" | "arm64") tiniArch="tini-static-$dpkgArch" ;;\
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+  cd /tmp \
+  && git clone https://github.com/ncopa/su-exec.git \
+  && cd su-exec \
+  && git checkout -q $SUEXEC_VERSION \
+  && make su-exec-static \
+  && cd /tmp \
+  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/$tiniArch \
+  && chmod +x tini
 
 # Now comes the actual target image, which aims to be as small as possible.
-FROM busybox:1.31.0-glibc
+FROM busybox:1.31.1-glibc
 LABEL maintainer="Textile <contact@textile.io>"
 
 # Get the textile binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /textile
-COPY --from=0 /textile/buckd /usr/local/bin/buckd
-COPY --from=0 /tmp/su-exec/su-exec /sbin/su-exec
+COPY --from=0 $SRC_DIR/buckd /usr/local/bin/buckd
+COPY --from=0 /tmp/su-exec/su-exec-static /sbin/su-exec
 COPY --from=0 /tmp/tini /sbin/tini
 COPY --from=0 /etc/ssl/certs /etc/ssl/certs
 
 # This shared lib (part of glibc) doesn't seem to be included with busybox.
-COPY --from=0 /lib/x86_64-linux-gnu/libdl.so.2 /lib/libdl.so.2
+COPY --from=0 /lib/*-linux-gnu*/libdl.so.2 /lib/
 
-# addrApi; should be exposed to the public
+# Copy over SSL libraries.
+COPY --from=0 /usr/lib/*-linux-gnu*/libssl.so* /usr/lib/
+COPY --from=0 /usr/lib/*-linux-gnu*/libcrypto.so* /usr/lib/
+
+# addrApi; can be exposed to the public.
 EXPOSE 3006
-# addrApiProxy; should be exposed to the public
+# addrApiProxy; can be exposed to the public.
 EXPOSE 3007
-# addrThreadsHost; should be exposed to the public
+# addrThreadsHost; must be exposed to the public.
 EXPOSE 4006
-# addrGatewayHost; should be exposed to the public
+# addrGatewayHost; can be exposed to the public.
 EXPOSE 8006
 
-# Create the repo directory and switch to a non-privileged user.
+# Create the repo directory.
 ENV BUCKETS_PATH /data/buckets
 RUN mkdir -p $BUCKETS_PATH \
-  && mkdir -p $BUCKETS_PATH/logstore \
-  && mkdir -p $BUCKETS_PATH/eventstore \
-  && mkdir -p $BUCKETS_PATH/ipfslite \
   && adduser -D -h $BUCKETS_PATH -u 1000 -G users buckets \
-  && chown -R buckets:users $BUCKETS_PATH
+  && chown buckets:users $BUCKETS_PATH
 
-# Switch to a non-privileged user
+# Switch to a non-privileged user.
 USER buckets
 
 # Expose the repo as a volume.
-# Important this happens after the USER directive so permission are correct.
+# Important this happens after adduser so permission are correct.
 VOLUME $BUCKETS_PATH
 
 ENTRYPOINT ["/sbin/tini", "--", "buckd"]

--- a/cmd/buckd/Dockerfile
+++ b/cmd/buckd/Dockerfile
@@ -78,7 +78,7 @@ RUN mkdir -p $BUCKETS_PATH \
 USER buckets
 
 # Expose the repo as a volume.
-# Important this happens after adduser so permission are correct.
+# Important this happens after the USER directive so permission are correct.
 VOLUME $BUCKETS_PATH
 
 ENTRYPOINT ["/sbin/tini", "--", "buckd"]

--- a/cmd/buckd/Dockerfile.dev
+++ b/cmd/buckd/Dockerfile.dev
@@ -1,0 +1,40 @@
+FROM golang:1.15.5-buster
+
+RUN apt-get update
+
+RUN go get github.com/go-delve/delve/cmd/dlv
+
+ENV SRC_DIR /textile
+
+COPY go.mod go.sum $SRC_DIR/
+RUN cd $SRC_DIR \
+  && go mod download
+
+COPY . $SRC_DIR
+
+RUN cd $SRC_DIR \
+  && CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -o buckd cmd/buckd/main.go
+
+FROM debian:buster
+LABEL maintainer="Textile <contact@textile.io>"
+
+ENV SRC_DIR /textile
+COPY --from=0 /go/bin/dlv /usr/local/bin/dlv
+COPY --from=0 /textile/buckd /usr/local/bin/buckd
+
+EXPOSE 3006
+EXPOSE 3007
+EXPOSE 4006
+EXPOSE 8006
+EXPOSE 40000
+
+ENV BUCKETS_PATH /data/buckets
+RUN adduser --home $BUCKETS_PATH --disabled-login --gecos "" --ingroup users buckets
+
+USER buckets
+
+VOLUME $BUCKETS_PATH
+
+ENTRYPOINT ["dlv", "--listen=0.0.0.0:40000", "--headless=true", "--accept-multiclient", "--continue", "--api-version=2", "exec", "/usr/local/bin/buckd"]
+
+CMD ["--", "--repo=/data/buckets"]

--- a/cmd/buckd/Dockerfile.dev
+++ b/cmd/buckd/Dockerfile.dev
@@ -20,7 +20,7 @@ LABEL maintainer="Textile <contact@textile.io>"
 
 ENV SRC_DIR /textile
 COPY --from=0 /go/bin/dlv /usr/local/bin/dlv
-COPY --from=0 /textile/buckd /usr/local/bin/buckd
+COPY --from=0 $SRC_DIR/buckd /usr/local/bin/buckd
 
 EXPOSE 3006
 EXPOSE 3007

--- a/cmd/buckd/docker-compose-dev.yml
+++ b/cmd/buckd/docker-compose-dev.yml
@@ -3,31 +3,40 @@ services:
   buckets:
     build:
       context: ../../
-      dockerfile: ./cmd/buckd/Dockerfile
+      dockerfile: ./cmd/buckd/Dockerfile.dev
+    volumes:
+      - "${REPO_PATH}/buckets:/data/buckets"
     environment:
       - BUCK_LOG_DEBUG=true
-      - BUCK_LOG_FILE
       - BUCK_ADDR_API=/ip4/0.0.0.0/tcp/3006
       - BUCK_ADDR_API_PROXY=/ip4/0.0.0.0/tcp/3007
       - BUCK_ADDR_MONGO_URI=mongodb://mongo:27017
-      - BUCK_ADDR_MONGO_NAME
+      - BUCK_ADDR_MONGO_NAME=buckets
       - BUCK_ADDR_THREADS_HOST=/ip4/0.0.0.0/tcp/4006
-      - BUCK_ADDR_THREADS_MONGO_URI
-      - BUCK_ADDR_THREADS_MONGO_NAME
+      - BUCK_ADDR_THREADS_MONGO_URI=mongodb://mongo:27017
+      - BUCK_ADDR_THREADS_MONGO_NAME=buckets_threads
       - BUCK_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8006
       - BUCK_ADDR_GATEWAY_URL
       - BUCK_ADDR_IPFS_API=/dns4/ipfs/tcp/5001
       - BUCK_ADDR_POWERGATE_API
       - BUCK_GATEWAY_SUBDOMAINS
+      - BUCK_DNS_DOMAIN
     ports:
       - "127.0.0.1:3006:3006"
-      - "3007:3007"
+      - "127.0.0.1:3007:3007"
       - "4006:4006"
       - "127.0.0.1:8006:8006"
+      - "127.0.0.1:40000:40000"
+    security_opt:
+      - "seccomp:unconfined"
+    cap_add:
+      - SYS_PTRACE
     depends_on:
       - mongo
   mongo:
     image: mongo:latest
+    volumes:
+      - "${REPO_PATH}/mongo:/data/db"
     ports:
       - "127.0.0.1:27017:27017"
     command:
@@ -39,7 +48,12 @@ services:
         tail -f /var/log/mongod.log
   ipfs:
     image: ipfs/go-ipfs:v0.7.0
+    volumes:
+      - "${REPO_PATH}/ipfs:/data/ipfs"
+    environment:
+      - IPFS_PROFILE=test
     ports:
       - "4001:4001"
+      - "4001:4001/udp"
       - "127.0.0.1:5001:5001"
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"

--- a/cmd/buckd/docker-compose.yml
+++ b/cmd/buckd/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - "${REPO_PATH}/buckets:/data/buckets"
     environment:
       - BUCK_LOG_DEBUG
-      - BUCK_LOG_FILE
       - BUCK_ADDR_API=/ip4/0.0.0.0/tcp/3006
       - BUCK_ADDR_API_PROXY=/ip4/0.0.0.0/tcp/3007
       - BUCK_ADDR_MONGO_URI=mongodb://mongo:27017
@@ -24,10 +23,10 @@ services:
       - BUCK_DNS_ZONE_ID
       - BUCK_DNS_TOKEN
     ports:
-      - "127.0.0.1:3006:3006"
+      - "3006:3006"
       - "3007:3007"
       - "4006:4006"
-      - "127.0.0.1:8006:8006"
+      - "8006:8006"
     depends_on:
       - mongo
   mongo:
@@ -51,5 +50,6 @@ services:
       - "${REPO_PATH}/ipfs:/data/ipfs"
     ports:
       - "4001:4001"
+      - "4001:4001/udp"
       - "127.0.0.1:5001:5001"
       - "8080:8080"

--- a/cmd/buckd/main.go
+++ b/cmd/buckd/main.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/textileio/go-threads/util"
@@ -34,7 +34,7 @@ var (
 			},
 			"logFile": {
 				Key:      "log.file",
-				DefValue: "${HOME}/." + daemonName + "/log",
+				DefValue: "", // no log file
 			},
 
 			// Addresses
@@ -230,7 +230,7 @@ var rootCmd = &cobra.Command{
 		debug := config.Viper.GetBool("log.debug")
 		logFile := config.Viper.GetString("log.file")
 		if logFile != "" {
-			err = util.SetupDefaultLoggingConfig(logFile)
+			err = cmd.SetupDefaultLoggingConfig(logFile)
 			cmd.ErrCheck(err)
 		}
 

--- a/cmd/hubd/Dockerfile
+++ b/cmd/hubd/Dockerfile
@@ -4,24 +4,11 @@ MAINTAINER Textile <contact@textile.io>
 # This is (in large part) copied (with love) from
 # https://hub.docker.com/r/ipfs/go-ipfs/dockerfile
 
-# Get the TLS CA certificates, they're not provided by busybox.
-RUN apt-get update && apt-get install -y ca-certificates
+# Install deps
+RUN apt-get update && apt-get install -y \
+  libssl-dev \
+  ca-certificates
 
-# Get su-exec, a very minimal tool for dropping privileges,
-# and tini, a very minimal init daemon for containers
-ENV SUEXEC_VERSION v0.2
-ENV TINI_VERSION v0.16.1
-RUN set -x \
-  && cd /tmp \
-  && git clone https://github.com/ncopa/su-exec.git \
-  && cd su-exec \
-  && git checkout -q $SUEXEC_VERSION \
-  && make \
-  && cd /tmp \
-  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
-  && chmod +x tini
-
-# Get source
 ENV SRC_DIR /textile
 
 # Download packages first so they can be cached.
@@ -31,40 +18,61 @@ RUN cd $SRC_DIR \
 
 COPY . $SRC_DIR
 
-# Install the daemon
-RUN cd $SRC_DIR && TXTL_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-hubd
+# Build the thing.
+RUN cd $SRC_DIR \
+  && TXTL_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-hubd
+
+# Get su-exec, a very minimal tool for dropping privileges,
+# and tini, a very minimal init daemon for containers
+ENV SUEXEC_VERSION v0.2
+ENV TINI_VERSION v0.19.0
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        "amd64" | "armhf" | "arm64") tiniArch="tini-static-$dpkgArch" ;;\
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+  cd /tmp \
+  && git clone https://github.com/ncopa/su-exec.git \
+  && cd su-exec \
+  && git checkout -q $SUEXEC_VERSION \
+  && make su-exec-static \
+  && cd /tmp \
+  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/$tiniArch \
+  && chmod +x tini
 
 # Now comes the actual target image, which aims to be as small as possible.
-FROM busybox:1.31.0-glibc
+FROM busybox:1.31.1-glibc
 LABEL maintainer="Textile <contact@textile.io>"
 
 # Get the textile binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /textile
-COPY --from=0 /textile/hubd /usr/local/bin/hubd
-COPY --from=0 /tmp/su-exec/su-exec /sbin/su-exec
+COPY --from=0 $SRC_DIR/hubd /usr/local/bin/hubd
+COPY --from=0 /tmp/su-exec/su-exec-static /sbin/su-exec
 COPY --from=0 /tmp/tini /sbin/tini
 COPY --from=0 /etc/ssl/certs /etc/ssl/certs
 
 # This shared lib (part of glibc) doesn't seem to be included with busybox.
-COPY --from=0 /lib/x86_64-linux-gnu/libdl.so.2 /lib/libdl.so.2
+COPY --from=0 /lib/*-linux-gnu*/libdl.so.2 /lib/
 
-# addrApi; should be exposed to the public
+# Copy over SSL libraries.
+COPY --from=0 /usr/lib/*-linux-gnu*/libssl.so* /usr/lib/
+COPY --from=0 /usr/lib/*-linux-gnu*/libcrypto.so* /usr/lib/
+
+# addrApi; can be exposed to the public.
 EXPOSE 3006
-# addrApiProxy; should be exposed to the public
+# addrApiProxy; can be exposed to the public.
 EXPOSE 3007
-# addrThreadsHost; should be exposed to the public
+# addrThreadsHost; must be exposed to the public.
 EXPOSE 4006
-# addrGatewayHost; should be exposed to the public
+# addrGatewayHost; can be exposed to the public.
 EXPOSE 8006
 
-# Create the repo directory and switch to a non-privileged user.
+# Create the repo directory.
 ENV TEXTILE_PATH /data/textile
 RUN mkdir -p $TEXTILE_PATH \
-  && mkdir -p $TEXTILE_PATH/logstore \
-  && mkdir -p $TEXTILE_PATH/eventstore \
-  && mkdir -p $TEXTILE_PATH/ipfslite \
   && adduser -D -h $TEXTILE_PATH -u 1000 -G users textile \
-  && chown -R textile:users $TEXTILE_PATH
+  && chown textile:users $TEXTILE_PATH
 
 # Switch to a non-privileged user.
 USER textile

--- a/cmd/hubd/Dockerfile.dev
+++ b/cmd/hubd/Dockerfile.dev
@@ -20,7 +20,7 @@ LABEL maintainer="Textile <contact@textile.io>"
 
 ENV SRC_DIR /textile
 COPY --from=0 /go/bin/dlv /usr/local/bin/dlv
-COPY --from=0 /textile/hubd /usr/local/bin/hubd
+COPY --from=0 $SRC_DIR/hubd /usr/local/bin/hubd
 
 EXPOSE 3006
 EXPOSE 3007

--- a/cmd/hubd/Dockerfile.dev
+++ b/cmd/hubd/Dockerfile.dev
@@ -1,0 +1,40 @@
+FROM golang:1.15.5-buster
+
+RUN apt-get update
+
+RUN go get github.com/go-delve/delve/cmd/dlv
+
+ENV SRC_DIR /textile
+
+COPY go.mod go.sum $SRC_DIR/
+RUN cd $SRC_DIR \
+  && go mod download
+
+COPY . $SRC_DIR
+
+RUN cd $SRC_DIR \
+  && CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -o hubd cmd/hubd/main.go
+
+FROM debian:buster
+LABEL maintainer="Textile <contact@textile.io>"
+
+ENV SRC_DIR /textile
+COPY --from=0 /go/bin/dlv /usr/local/bin/dlv
+COPY --from=0 /textile/hubd /usr/local/bin/hubd
+
+EXPOSE 3006
+EXPOSE 3007
+EXPOSE 4006
+EXPOSE 8006
+EXPOSE 40000
+
+ENV TEXTILE_PATH /data/textile
+RUN adduser --home $TEXTILE_PATH --disabled-login --gecos "" --ingroup users textile
+
+USER textile
+
+VOLUME $TEXTILE_PATH
+
+ENTRYPOINT ["dlv", "--listen=0.0.0.0:40000", "--headless=true", "--accept-multiclient", "--continue", "--api-version=2", "exec", "/usr/local/bin/hubd"]
+
+CMD ["--", "--repo=/data/textile"]

--- a/cmd/hubd/docker-compose-dev.yml
+++ b/cmd/hubd/docker-compose-dev.yml
@@ -3,17 +3,18 @@ services:
   textile:
     build:
       context: ../../
-      dockerfile: ./cmd/hubd/Dockerfile
+      dockerfile: ./cmd/hubd/Dockerfile.dev
+    volumes:
+      - "${REPO_PATH}/textile:/data/textile"
     environment:
       - HUB_LOG_DEBUG=true
-      - HUB_LOG_FILE
       - HUB_ADDR_API=/ip4/0.0.0.0/tcp/3006
       - HUB_ADDR_API_PROXY=/ip4/0.0.0.0/tcp/3007
       - HUB_ADDR_MONGO_URI=mongodb://mongo:27017
-      - HUB_ADDR_MONGO_NAME
+      - HUB_ADDR_MONGO_NAME=textile
       - HUB_ADDR_THREADS_HOST=/ip4/0.0.0.0/tcp/4006
-      - HUB_ADDR_THREADS_MONGO_URI
-      - HUB_ADDR_THREADS_MONGO_NAME
+      - HUB_ADDR_THREADS_MONGO_URI=mongodb://mongo:27017
+      - HUB_ADDR_THREADS_MONGO_NAME=textile_threads
       - HUB_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8006
       - HUB_ADDR_GATEWAY_URL
       - HUB_ADDR_IPFS_API=/dns4/ipfs/tcp/5001
@@ -28,19 +29,25 @@ services:
       - HUB_SEGMENT_PREFIX
     ports:
       - "127.0.0.1:3006:3006"
-      - "3007:3007"
+      - "127.0.0.1:3007:3007"
       - "4006:4006"
       - "127.0.0.1:8006:8006"
+      - "127.0.0.1:40000:40000"
+    security_opt:
+      - "seccomp:unconfined"
+    cap_add:
+      - SYS_PTRACE
+    depends_on:
+      - mongo
   billing:
     build:
       context: ../../
-      dockerfile: ./api/billingd/Dockerfile
+      dockerfile: ./api/billingd/Dockerfile.dev
     environment:
       - BILLING_LOG_DEBUG=true
-      - BILLING_LOG_FILE
       - BILLING_ADDR_API=/ip4/0.0.0.0/tcp/10006
       - BILLING_ADDR_MONGO_URI=mongodb://mongo:27017
-      - BILLING_ADDR_MONGO_NAME
+      - BILLING_ADDR_MONGO_NAME=textile_billing
       - BILLING_ADDR_GATEWAY_HOST=/ip4/0.0.0.0/tcp/8010
       - BILLING_ADDR_GATEWAY_URL
       - BILLING_STRIPE_API_KEY
@@ -49,10 +56,17 @@ services:
     ports:
       - "127.0.0.1:10006:10006"
       - "127.0.0.1:8010:8010"
+      - "127.0.0.1:40001:40000"
+    security_opt:
+      - "seccomp:unconfined"
+    cap_add:
+      - SYS_PTRACE
     depends_on:
       - mongo
   mongo:
     image: mongo:latest
+    volumes:
+      - "${REPO_PATH}/mongo:/data/db"
     ports:
       - "127.0.0.1:27017:27017"
     command:
@@ -64,7 +78,12 @@ services:
         tail -f /var/log/mongod.log
   ipfs:
     image: ipfs/go-ipfs:v0.7.0
+    volumes:
+      - "${REPO_PATH}/ipfs:/data/ipfs"
+    environment:
+      - IPFS_PROFILE=test
     ports:
       - "4001:4001"
+      - "4001:4001/udp"
       - "127.0.0.1:5001:5001"
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"

--- a/cmd/hubd/docker-compose.yml
+++ b/cmd/hubd/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - "${REPO_PATH}/textile:/data/textile"
     environment:
       - HUB_LOG_DEBUG
-      - HUB_LOG_FILE
       - HUB_ADDR_API=/ip4/0.0.0.0/tcp/3006
       - HUB_ADDR_API_PROXY=/ip4/0.0.0.0/tcp/3007
       - HUB_ADDR_MONGO_URI=mongodb://mongo:27017
@@ -30,10 +29,10 @@ services:
       - HUB_SEGMENT_API_KEY
       - HUB_SEGMENT_PREFIX
     ports:
-      - "127.0.0.1:3006:3006"
+      - "3006:3006"
       - "3007:3007"
       - "4006:4006"
-      - "127.0.0.1:8006:8006"
+      - "8006:8006"
     depends_on:
       - mongo
   billing:
@@ -41,7 +40,6 @@ services:
     restart: always
     environment:
       - BILLING_LOG_DEBUG
-      - BILLING_LOG_FILE
       - BILLING_ADDR_API=/ip4/0.0.0.0/tcp/10006
       - BILLING_ADDR_MONGO_URI=mongodb://mongo:27017
       - BILLING_ADDR_MONGO_NAME
@@ -51,8 +49,8 @@ services:
       - BILLING_SEGMENT_API_KEY
       - BILLING_SEGMENT_PREFIX
     ports:
-      - "127.0.0.1:10006:10006"
-      - "127.0.0.1:8010:8010"
+      - "10006:10006"
+      - "8010:8010"
     depends_on:
       - mongo
   mongo:
@@ -76,5 +74,6 @@ services:
       - "${REPO_PATH}/ipfs:/data/ipfs"
     ports:
       - "4001:4001"
+      - "4001:4001/udp"
       - "127.0.0.1:5001:5001"
       - "8080:8080"

--- a/cmd/hubd/main.go
+++ b/cmd/hubd/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/textileio/go-threads/util"
@@ -40,7 +40,7 @@ var (
 			},
 			"logFile": {
 				Key:      "log.file",
-				DefValue: "${HOME}/." + daemonName + "/log",
+				DefValue: "", // no log file
 			},
 
 			// Addresses
@@ -366,7 +366,7 @@ var rootCmd = &cobra.Command{
 		debug := config.Viper.GetBool("log.debug")
 		logFile := config.Viper.GetString("log.file")
 		if logFile != "" {
-			err = util.SetupDefaultLoggingConfig(logFile)
+			err = cmd.SetupDefaultLoggingConfig(logFile)
 			cmd.ErrCheck(err)
 		}
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"strings"
 
+	logging "github.com/ipfs/go-log/v2"
 	aurora2 "github.com/logrusorgru/aurora"
 	"github.com/olekukonko/tablewriter"
 	"github.com/textileio/textile/v2/api/billingd/common"
@@ -87,15 +89,6 @@ func ErrCheck(err error, args ...interface{}) {
 	}
 }
 
-func HandleInterrupt(stop func()) {
-	quit := make(chan os.Signal)
-	signal.Notify(quit, os.Interrupt)
-	<-quit
-	fmt.Println("Gracefully stopping... (press Ctrl+C again to force)")
-	stop()
-	os.Exit(1)
-}
-
 func RenderTable(header []string, data [][]string) {
 	fmt.Println()
 	table := tablewriter.NewWriter(os.Stdout)
@@ -119,4 +112,29 @@ func RenderTable(header []string, data [][]string) {
 	table.AppendBulk(data)
 	table.Render()
 	fmt.Println()
+}
+
+func HandleInterrupt(stop func()) {
+	quit := make(chan os.Signal)
+	signal.Notify(quit, os.Interrupt)
+	<-quit
+	fmt.Println("Gracefully stopping... (press Ctrl+C again to force)")
+	stop()
+	os.Exit(1)
+}
+
+func SetupDefaultLoggingConfig(file string) error {
+	if file != "" {
+		if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
+			return err
+		}
+	}
+	c := logging.Config{
+		Format: logging.ColorizedOutput,
+		Stderr: true,
+		File:   file,
+		Level:  logging.LevelError,
+	}
+	logging.SetupLogging(c)
+	return nil
 }

--- a/core/core.go
+++ b/core/core.go
@@ -12,7 +12,7 @@ import (
 	auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	httpapi "github.com/ipfs/go-ipfs-http-client"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
 	connmgr "github.com/libp2p/go-libp2p-core/connmgr"

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	cf "github.com/cloudflare/cloudflare-go"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/textileio/go-threads/util"
 )
 

--- a/email/email.go
+++ b/email/email.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	cio "github.com/customerio/go-customerio"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/textileio/go-threads/util"
 )
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
 	"github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	isd "github.com/jbenet/go-is-domain"
 	"github.com/libp2p/go-libp2p-core/peer"

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/ipfs/go-ipfs-http-client v0.1.0
 	github.com/ipfs/go-ipld-cbor v0.0.5
 	github.com/ipfs/go-ipld-format v0.2.0
-	github.com/ipfs/go-log v1.0.4
+	github.com/ipfs/go-log/v2 v2.1.2-0.20200626104915-0016c0b4b3e4
 	github.com/ipfs/go-merkledag v0.3.2
 	github.com/ipfs/go-unixfs v0.2.4
 	github.com/ipfs/interface-go-ipfs-core v0.4.0

--- a/ipns/ipns.go
+++ b/ipns/ipns.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	"github.com/ipfs/interface-go-ipfs-core/options"
 	"github.com/ipfs/interface-go-ipfs-core/path"

--- a/mongodb/migrations/migrations.go
+++ b/mongodb/migrations/migrations.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	migrate "github.com/xakep666/mongo-migrate"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"


### PR DESCRIPTION
I've had a local branch with a bunch of docker edits for awhile, but haven't had the time to make a real PR. Here goes...

- This updates all docker images to newer versions of `tini` and `busybox`.
- Properly sets a non-privileged user instead of root and uses its home dir as the data dir (same dir, just now it's the user home as well).
- Now, doing `make hub-up` or `make buck-up` will leverage new development images that allow for remote debugging by using a `dlv` based `ENTRYPOINT` and some additional `-gcflags`. Start a debug session with [delve](https://github.com/go-delve/delve), or via an IDE (GoLand shown below). Using the dev docker compose files, the `textile` and `buckets` services exposes port `40000` for debugging (since you wouldn't run them at the same time), and `billing` exposes port `40001`. This allows you to spin the whole stack locally with one line and still get debugging.

![Screen Shot 2020-12-30 at 9 08 01 PM](https://user-images.githubusercontent.com/361000/103395847-111cd300-4ae5-11eb-8bec-6bdee9e2cbec.png)

- Fixes the log file handling for all binaries. Previously, all log files were titled `threads.log` since a `go-threads` util was being used everywhere. Related, the log file must now be specified, which is a more expected behavior. The default now is just to log to `stdout`.