### PR TITLE
feat(buck): extend the command links with ability to set the output format

### DIFF
--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -77,6 +77,9 @@ func Init(baseCmd *cobra.Command) {
 	archiveCmd.Flags().BoolP("yes", "y", false, "Skips the confirmation prompt if true")
 
 	rolesGrantCmd.Flags().StringP("role", "r", "", "Access role: none, reader, writer, admin")
+
+	linksCmd.Flags().BoolP("json", "", false, "Display URL links as json object")
+	linksCmd.Flags().StringP("format", "", "", "Display URL links in the provided format. Options: [json]")
 }
 
 func SetBucks(b *local.Buckets) {
@@ -200,16 +203,30 @@ var linksCmd = &cobra.Command{
 		}
 		links, err := buck.RemoteLinks(ctx, pth)
 		cmd.ErrCheck(err)
-		printLinks(links)
+
+		jsonFormat, err := c.Flags().GetBool("json")
+		cmd.ErrCheck(err)
+		format, err := c.Flags().GetString("format")
+		cmd.ErrCheck(err)
+
+		if jsonFormat == true {
+			format = "json"
+		}
+
+		printLinks(links, format)
 	},
 }
 
-func printLinks(reply local.Links) {
-	cmd.Message("Your bucket links:")
-	cmd.Message("%s Thread link", aurora.White(reply.URL).Bold())
-	cmd.Message("%s IPNS link (propagation can be slow)", aurora.White(reply.IPNS).Bold())
-	if reply.WWW != "" {
-		cmd.Message("%s Bucket website", aurora.White(reply.WWW).Bold())
+func printLinks(reply local.Links, format string) {
+	if format == "json" {
+		cmd.JSON(reply)
+	} else {
+		cmd.Message("Your bucket links:")
+		cmd.Message("%s Thread link", aurora.White(reply.URL).Bold())
+		cmd.Message("%s IPNS link (propagation can be slow)", aurora.White(reply.IPNS).Bold())
+		if reply.WWW != "" {
+			cmd.Message("%s Bucket website", aurora.White(reply.WWW).Bold())
+		}
 	}
 }
 

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -20,6 +20,13 @@ var bucks *local.Buckets
 
 var aurora = aurora2.NewAurora(runtime.GOOS != "windows")
 
+type Format string
+
+const (
+	Default Format = "default"
+	JSON           = "json"
+)
+
 func init() {
 	uiprogress.Empty = ' '
 	uiprogress.Fill = '-'
@@ -79,7 +86,7 @@ func Init(baseCmd *cobra.Command) {
 	rolesGrantCmd.Flags().StringP("role", "r", "", "Access role: none, reader, writer, admin")
 
 	linksCmd.Flags().Bool("json", false, "Display URL links as json object")
-	linksCmd.Flags().String("format", "", "Display URL links in the provided format. Options: [json]")
+	linksCmd.Flags().String("format", "default", "Display URL links in the provided format. Options: [json]")
 }
 
 func SetBucks(b *local.Buckets) {
@@ -213,11 +220,11 @@ var linksCmd = &cobra.Command{
 			format = "json"
 		}
 
-		printLinks(links, format)
+		printLinks(links, Format(format))
 	},
 }
 
-func printLinks(reply local.Links, format string) {
+func printLinks(reply local.Links, format Format) {
 	if format == "json" {
 		cmd.JSON(reply)
 	} else {

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -78,8 +78,8 @@ func Init(baseCmd *cobra.Command) {
 
 	rolesGrantCmd.Flags().StringP("role", "r", "", "Access role: none, reader, writer, admin")
 
-	linksCmd.Flags().BoolP("json", "", false, "Display URL links as json object")
-	linksCmd.Flags().StringP("format", "", "", "Display URL links in the provided format. Options: [json]")
+	linksCmd.Flags().Bool("json", false, "Display URL links as json object")
+	linksCmd.Flags().String("format", "", "Display URL links in the provided format. Options: [json]")
 }
 
 func SetBucks(b *local.Buckets) {

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -85,7 +85,6 @@ func Init(baseCmd *cobra.Command) {
 
 	rolesGrantCmd.Flags().StringP("role", "r", "", "Access role: none, reader, writer, admin")
 
-	linksCmd.Flags().Bool("json", false, "Display URL links as json object")
 	linksCmd.Flags().String("format", "default", "Display URL links in the provided format. Options: [json]")
 }
 
@@ -211,14 +210,8 @@ var linksCmd = &cobra.Command{
 		links, err := buck.RemoteLinks(ctx, pth)
 		cmd.ErrCheck(err)
 
-		jsonFormat, err := c.Flags().GetBool("json")
-		cmd.ErrCheck(err)
 		format, err := c.Flags().GetString("format")
 		cmd.ErrCheck(err)
-
-		if jsonFormat == true {
-			format = "json"
-		}
 
 		printLinks(links, Format(format))
 	},

--- a/cmd/buck/cli/init.go
+++ b/cmd/buck/cli/init.go
@@ -163,7 +163,7 @@ Use the '--cid' flag to initialize from an existing UnixFS DAG.
 
 		links, err := buck.RemoteLinks(ctx, "")
 		cmd.ErrCheck(err)
-		printLinks(links, "")
+		printLinks(links, Default)
 
 		var msg string
 		if !existing {

--- a/cmd/buck/cli/init.go
+++ b/cmd/buck/cli/init.go
@@ -163,7 +163,7 @@ Use the '--cid' flag to initialize from an existing UnixFS DAG.
 
 		links, err := buck.RemoteLinks(ctx, "")
 		cmd.ErrCheck(err)
-		printLinks(links)
+		printLinks(links, "")
 
 		var msg string
 		if !existing {


### PR DESCRIPTION
Add the flag `--format`. The flag --format accepts a string to define the output format.
Add support for the format 'json'. If the format is set to json the link struct is printed as parsable JSON object.
Add the flag `--json`. The flag `--json` sets the flag --format to json

With this extension, the link command can be used in an automated environment. For example in a CI script.

I think it makes sense to add the flags for other commands as well.

---
*I completely new at go. I do not know if the changes are compliant with the go standards.*

