### PR TITLE
Fix default dns token flag

### DIFF
--- a/cmd/buckd/main.go
+++ b/cmd/buckd/main.go
@@ -196,7 +196,7 @@ func init() {
 		"Cloudflare ZoneID for dnsDomain")
 	rootCmd.PersistentFlags().String(
 		"dnsToken",
-		config.Flags["dnsDomain"].DefValue.(string),
+		config.Flags["dnsToken"].DefValue.(string),
 		"Cloudflare API Token for dnsDomain")
 
 	err := cmd.BindFlags(config.Viper, rootCmd, config.Flags)

--- a/cmd/hubd/main.go
+++ b/cmd/hubd/main.go
@@ -303,7 +303,7 @@ func init() {
 		"Cloudflare ZoneID for dnsDomain")
 	rootCmd.PersistentFlags().String(
 		"dnsToken",
-		config.Flags["dnsDomain"].DefValue.(string),
+		config.Flags["dnsToken"].DefValue.(string),
 		"Cloudflare API Token for dnsDomain")
 
 	// Customer.io


### PR DESCRIPTION
While defining the commands `hubd` and `buckd` the default values for the flag `dnsToken` is not correctly access from the Flags map. Currently, the value `dnsDomain` is used as the default for the flag `dnsToken`.