### PR TITLE
Buck init without discarding local changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,7 @@ diff, err := mybuck.DiffLocal() // diff contains staged changes
 
 `buckets.NewBucket` will write a local config file and data repo.
 
-See `local.WithName`, `local.WithPrivate`, `local.WithCid`, `local.WithExistingPathEvents` for more options when creating buckets.
+See `local.WithName`, `local.WithStrategy`, `local.WithPrivate`, `local.WithCid`, `local.WithInitPathEvents` for more options when creating buckets.
 
 To create a bucket from an existing remote, use its thread ID and instance ID (bucket `key`) in the config.
 

--- a/api/bucketsd/client/client.go
+++ b/api/bucketsd/client/client.go
@@ -3,8 +3,7 @@ package client
 import (
 	"context"
 	"io"
-	"runtime"
-	"strings"
+	"path/filepath"
 
 	"github.com/gogo/status"
 	"github.com/ipfs/go-cid"
@@ -73,7 +72,7 @@ func (c *Client) Root(ctx context.Context, key string) (*pb.RootResponse, error)
 func (c *Client) Links(ctx context.Context, key, pth string) (*pb.LinksResponse, error) {
 	return c.c.Links(ctx, &pb.LinksRequest{
 		Key:  key,
-		Path: normalizePath(pth),
+		Path: filepath.ToSlash(pth),
 	})
 }
 
@@ -91,7 +90,7 @@ func (c *Client) ListIpfsPath(ctx context.Context, pth path.Path) (*pb.ListIpfsP
 func (c *Client) ListPath(ctx context.Context, key, pth string) (*pb.ListPathResponse, error) {
 	return c.c.ListPath(ctx, &pb.ListPathRequest{
 		Key:  key,
-		Path: normalizePath(pth),
+		Path: filepath.ToSlash(pth),
 	})
 }
 
@@ -99,7 +98,7 @@ func (c *Client) ListPath(ctx context.Context, key, pth string) (*pb.ListPathRes
 func (c *Client) SetPath(ctx context.Context, key, pth string, remoteCid cid.Cid) (*pb.SetPathResponse, error) {
 	return c.c.SetPath(ctx, &pb.SetPathRequest{
 		Key:  key,
-		Path: normalizePath(pth),
+		Path: filepath.ToSlash(pth),
 		Cid:  remoteCid.String(),
 	})
 }
@@ -133,7 +132,7 @@ func (c *Client) PushPath(ctx context.Context, key, pth string, reader io.Reader
 		Payload: &pb.PushPathRequest_Header_{
 			Header: &pb.PushPathRequest_Header{
 				Key:  key,
-				Path: normalizePath(pth),
+				Path: filepath.ToSlash(pth),
 				Root: xr,
 			},
 		},
@@ -218,7 +217,7 @@ func (c *Client) PullPath(ctx context.Context, key, pth string, writer io.Writer
 
 	stream, err := c.c.PullPath(ctx, &pb.PullPathRequest{
 		Key:  key,
-		Path: normalizePath(pth),
+		Path: filepath.ToSlash(pth),
 	})
 	if err != nil {
 		return err
@@ -303,7 +302,7 @@ func (c *Client) RemovePath(ctx context.Context, key, pth string, opts ...Option
 	}
 	res, err := c.c.RemovePath(ctx, &pb.RemovePathRequest{
 		Key:  key,
-		Path: normalizePath(pth),
+		Path: filepath.ToSlash(pth),
 		Root: xr,
 	})
 	if err != nil {
@@ -323,7 +322,7 @@ func (c *Client) PushPathAccessRoles(ctx context.Context, key, pth string, roles
 	}
 	_, err = c.c.PushPathAccessRoles(ctx, &pb.PushPathAccessRolesRequest{
 		Key:   key,
-		Path:  normalizePath(pth),
+		Path:  filepath.ToSlash(pth),
 		Roles: pbroles,
 	})
 	return err
@@ -333,7 +332,7 @@ func (c *Client) PushPathAccessRoles(ctx context.Context, key, pth string, roles
 func (c *Client) PullPathAccessRoles(ctx context.Context, key, pth string) (map[string]buckets.Role, error) {
 	res, err := c.c.PullPathAccessRoles(ctx, &pb.PullPathAccessRolesRequest{
 		Key:  key,
-		Path: normalizePath(pth),
+		Path: filepath.ToSlash(pth),
 	})
 	if err != nil {
 		return nil, err
@@ -396,11 +395,4 @@ func (c *Client) ArchiveWatch(ctx context.Context, key string, ch chan<- string)
 		ch <- reply.Msg
 	}
 	return nil
-}
-
-func normalizePath(pth string) string {
-	if runtime.GOOS == "windows" {
-		pth = strings.ReplaceAll(pth, "\\", "/")
-	}
-	return pth
 }

--- a/buckets/local/bucket.go
+++ b/buckets/local/bucket.go
@@ -125,7 +125,7 @@ func (b *Bucket) LocalSize() (int64, error) {
 			return fmt.Errorf("getting fileinfo of %s: %s", n, err)
 		}
 		if !info.IsDir() {
-			f := strings.TrimPrefix(n, bp+"/")
+			f := strings.TrimPrefix(n, bp+string(os.PathSeparator))
 			if Ignore(n) || (strings.HasPrefix(f, b.conf.Dir) && f != buckets.SeedName) {
 				return nil
 			}

--- a/buckets/local/bucket_test.go
+++ b/buckets/local/bucket_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-merkledag/dagutils"
+	du "github.com/ipfs/go-merkledag/dagutils"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -205,7 +205,7 @@ func TestBucket_PullRemote(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, diff, 1)
 	if len(diff) > 0 {
-		assert.Equal(t, diff[0].Type, dagutils.Remove)
+		assert.Equal(t, diff[0].Type, du.Remove)
 	}
 
 	// Pulling hard should reset the local to the exact state of the remote
@@ -357,7 +357,7 @@ func TestBucket_DiffLocal(t *testing.T) {
 	diff, err := buck.DiffLocal()
 	require.NoError(t, err)
 	assert.Len(t, diff, 2)
-	assert.Equal(t, diff[0].Type, dagutils.Add)
+	assert.Equal(t, diff[0].Type, du.Add)
 
 	// Test diff from a nested folder
 	buck2, err := buckets.GetLocalBucket(context.Background(), Config{Path: filepath.Join(conf.Path, "folder")})
@@ -365,7 +365,7 @@ func TestBucket_DiffLocal(t *testing.T) {
 	diff, err = buck2.DiffLocal()
 	require.NoError(t, err)
 	assert.Len(t, diff, 2)
-	assert.Equal(t, diff[0].Type, dagutils.Add)
+	assert.Equal(t, diff[0].Type, du.Add)
 
 	_, err = buck.PushLocal(context.Background())
 	require.NoError(t, err)
@@ -378,7 +378,7 @@ func TestBucket_DiffLocal(t *testing.T) {
 	diff, err = buck.DiffLocal()
 	require.NoError(t, err)
 	assert.Len(t, diff, 1)
-	assert.Equal(t, diff[0].Type, dagutils.Mod)
+	assert.Equal(t, diff[0].Type, du.Mod)
 
 	_, err = buck.PushLocal(context.Background())
 	require.NoError(t, err)
@@ -392,7 +392,7 @@ func TestBucket_DiffLocal(t *testing.T) {
 	diff, err = buck.DiffLocal()
 	require.NoError(t, err)
 	assert.Len(t, diff, 1)
-	assert.Equal(t, diff[0].Type, dagutils.Remove)
+	assert.Equal(t, diff[0].Type, du.Remove)
 
 	_, err = buck.PushLocal(context.Background())
 	require.NoError(t, err)

--- a/buckets/local/buckets.go
+++ b/buckets/local/buckets.go
@@ -231,28 +231,29 @@ func (b *Buckets) NewBucket(ctx context.Context, conf Config, opts ...NewOption)
 		if err := buck.repo.Save(ctx); err != nil {
 			return nil, err
 		}
-		if args.sync {
-			if _, err := buck.getPath(ctx, "", cwd, nil, false, args.events); err != nil {
-				return nil, err
-			}
-			if err := buck.repo.Save(ctx); err != nil {
-				return nil, err
-			}
-		} else {
-			diff, missing, removed, err := buck.diffPath(ctx, "", cwd)
+		switch args.strategy {
+		case Soft, Hybrid:
+			diff, missing, remove, err := buck.diffPath(ctx, "", cwd, args.strategy == Hybrid)
 			if err != nil {
 				return nil, err
 			}
 			if err = stashChanges(diff); err != nil {
 				return nil, err
 			}
-			if _, err = buck.handleChanges(ctx, "", missing, removed, args.events); err != nil {
+			if _, err = buck.handleChanges(ctx, "", missing, remove, args.events); err != nil {
 				return nil, err
 			}
 			if err := buck.repo.Save(ctx); err != nil {
 				return nil, err
 			}
 			if err = applyChanges(diff); err != nil {
+				return nil, err
+			}
+		case Hard:
+			if _, err := buck.getPath(ctx, "", cwd, nil, false, args.events); err != nil {
+				return nil, err
+			}
+			if err := buck.repo.Save(ctx); err != nil {
 				return nil, err
 			}
 		}

--- a/buckets/local/buckets_test.go
+++ b/buckets/local/buckets_test.go
@@ -88,7 +88,7 @@ func TestBuckets_NewBucket(t *testing.T) {
 		defer close(events)
 		ec := &eventCollector{}
 		go ec.collect(events)
-		buck, err := buckets.NewBucket(context.Background(), conf, WithCid(pth.Cid()), WithExistingPathEvents(events))
+		buck, err := buckets.NewBucket(context.Background(), conf, WithCid(pth.Cid()), WithInitPathEvents(events))
 		require.NoError(t, err)
 		assert.NotEmpty(t, buck)
 		ec.check(t, 2, 0)

--- a/buckets/local/diff.go
+++ b/buckets/local/diff.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/ipfs/go-merkledag/dagutils"
+	du "github.com/ipfs/go-merkledag/dagutils"
 	aurora2 "github.com/logrusorgru/aurora"
 	"github.com/textileio/textile/v2/buckets"
 	"github.com/textileio/textile/v2/cmd"
@@ -17,20 +17,20 @@ var aurora = aurora2.NewAurora(runtime.GOOS != "windows")
 
 // Change describes a local bucket change.
 type Change struct {
-	Type dagutils.ChangeType
+	Type du.ChangeType
 	Name string // Absolute file name
 	Path string // File name relative to the bucket root
 	Rel  string // File name relative to the bucket current working directory
 }
 
 // ChangeType returns a string representation of a change type.
-func ChangeType(t dagutils.ChangeType) string {
+func ChangeType(t du.ChangeType) string {
 	switch t {
-	case dagutils.Mod:
+	case du.Mod:
 		return "modified:"
-	case dagutils.Add:
+	case du.Add:
 		return "new file:"
-	case dagutils.Remove:
+	case du.Remove:
 		return "deleted: "
 	default:
 		return ""
@@ -38,13 +38,13 @@ func ChangeType(t dagutils.ChangeType) string {
 }
 
 // ChangeColor returns an appropriate color for the given change type.
-func ChangeColor(t dagutils.ChangeType) func(arg interface{}) aurora2.Value {
+func ChangeColor(t du.ChangeType) func(arg interface{}) aurora2.Value {
 	switch t {
-	case dagutils.Mod:
+	case du.Mod:
 		return aurora.Yellow
-	case dagutils.Add:
+	case du.Add:
 		return aurora.Green
-	case dagutils.Remove:
+	case du.Remove:
 		return aurora.Red
 	default:
 		return nil
@@ -74,7 +74,7 @@ func (b *Bucket) DiffLocal() ([]Change, error) {
 	for _, c := range diff {
 		fp := filepath.Join(bp, c.Path)
 		switch c.Type {
-		case dagutils.Mod, dagutils.Add:
+		case du.Mod, du.Add:
 			names, err := b.walkPath(fp)
 			if err != nil {
 				return nil, err
@@ -87,7 +87,7 @@ func (b *Bucket) DiffLocal() ([]Change, error) {
 				}
 				all = append(all, Change{Type: c.Type, Name: n, Path: p, Rel: r})
 			}
-		case dagutils.Remove:
+		case du.Remove:
 			r, err := filepath.Rel(b.cwd, fp)
 			if err != nil {
 				return nil, err

--- a/buckets/local/list.go
+++ b/buckets/local/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/ipfs/go-cid"
 	pb "github.com/textileio/textile/v2/api/bucketsd/pb"
@@ -24,6 +25,7 @@ type BucketItem struct {
 
 // ListRemotePath returns a list of all bucket items under path.
 func (b *Bucket) ListRemotePath(ctx context.Context, pth string) (items []BucketItem, err error) {
+	pth = filepath.ToSlash(pth)
 	if pth == "." || pth == "/" || pth == "./" {
 		pth = ""
 	}

--- a/buckets/local/options.go
+++ b/buckets/local/options.go
@@ -8,6 +8,7 @@ type newOptions struct {
 	name    string
 	private bool
 	fromCid cid.Cid
+	sync    bool
 	events  chan<- PathEvent
 }
 
@@ -33,6 +34,13 @@ func WithPrivate(private bool) NewOption {
 func WithCid(c cid.Cid) NewOption {
 	return func(args *newOptions) {
 		args.fromCid = c
+	}
+}
+
+// WithSync syncs bucket state with the remote. All local changes will be discarded.
+func WithSync(sync bool) NewOption {
+	return func(args *newOptions) {
+		args.sync = sync
 	}
 }
 

--- a/buckets/local/pull.go
+++ b/buckets/local/pull.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	du "github.com/ipfs/go-merkledag/dagutils"
+
 	cid "github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-merkledag/dagutils"
 	"github.com/textileio/textile/v2/api/bucketsd/client"
 	"golang.org/x/sync/errgroup"
 )
@@ -43,15 +44,10 @@ func (b *Bucket) PullRemote(ctx context.Context, opts ...PathOption) (roots Root
 		}
 	}
 
-	// Tmp move local modifications and additions if not pulling hard
+	// Stash local modifications and additions if not pulling hard
 	if !args.hard {
-		for _, c := range diff {
-			switch c.Type {
-			case dagutils.Mod, dagutils.Add:
-				if err := os.Rename(c.Name, c.Name+".buckpatch"); err != nil {
-					return roots, err
-				}
-			}
+		if err := stashChanges(diff); err != nil {
+			return roots, err
 		}
 	}
 
@@ -59,11 +55,11 @@ func (b *Bucket) PullRemote(ctx context.Context, opts ...PathOption) (roots Root
 	if err != nil {
 		return
 	}
-	count, err := b.getPath(ctx, "", bp, diff, args.force, args.events)
+	changes, err := b.getPath(ctx, "", bp, diff, args.force, args.events)
 	if err != nil {
 		return
 	}
-	if count == 0 {
+	if changes == 0 {
 		return roots, ErrUpToDate
 	}
 
@@ -82,31 +78,25 @@ func (b *Bucket) PullRemote(ctx context.Context, opts ...PathOption) (roots Root
 
 	// Re-apply local changes if not pulling hard
 	if !args.hard {
-		for _, c := range diff {
-			switch c.Type {
-			case dagutils.Mod, dagutils.Add:
-				if err := os.Rename(c.Name+".buckpatch", c.Name); err != nil {
-					return roots, err
-				}
-			case dagutils.Remove:
-				// If the file was also deleted on the remote,
-				// the local deletion will already have been handled by getPath.
-				// So, we just ignore the error here.
-				_ = os.RemoveAll(c.Name)
-			}
+		if err := applyChanges(diff); err != nil {
+			return roots, err
 		}
 	}
 	return b.Roots(ctx)
 }
 
-func (b *Bucket) getPath(ctx context.Context, pth, dest string, diff []Change, force bool, events chan<- PathEvent) (count int, err error) {
-	key := b.Key()
-	all, missing, err := b.listPath(ctx, key, pth, dest, force)
+func (b *Bucket) getPath(
+	ctx context.Context,
+	pth, dest string,
+	diff []Change,
+	force bool,
+	events chan<- PathEvent,
+) (changes int, err error) {
+	all, missing, err := b.listPath(ctx, pth, dest, force)
 	if err != nil {
 		return
 	}
-	count = len(missing)
-	rm := make(map[string]string)
+	removed := make(map[string]string)
 	list, err := b.walkPath(dest)
 	if err != nil {
 		return
@@ -118,8 +108,8 @@ loop:
 				continue loop
 			}
 		}
-		p := strings.TrimPrefix(n, dest+"/")
-		rm[p] = n
+		p := strings.TrimPrefix(n, dest+string(os.PathSeparator))
+		removed[p] = n
 	}
 looop:
 	for _, l := range diff {
@@ -128,11 +118,23 @@ looop:
 				continue looop
 			}
 		}
-		if _, ok := rm[l.Path]; !ok {
-			rm[l.Path] = l.Name
+		if _, ok := removed[l.Path]; !ok {
+			removed[l.Path] = l.Name
 		}
 	}
-	count += len(rm)
+
+	return b.handleChanges(ctx, pth, missing, removed, events)
+}
+
+func (b *Bucket) handleChanges(
+	ctx context.Context,
+	pth string,
+	missing []object,
+	removed map[string]string,
+	events chan<- PathEvent,
+) (count int, err error) {
+	count = len(missing)
+	count += len(removed)
 	if count == 0 {
 		return
 	}
@@ -154,7 +156,7 @@ looop:
 				if gctx.Err() != nil {
 					return nil
 				}
-				if err := b.getFile(ctx, key, o, events); err != nil {
+				if err := b.getFile(ctx, b.Key(), o, events); err != nil {
 					return err
 				}
 				if b.repo != nil {
@@ -170,19 +172,24 @@ looop:
 			return count, err
 		}
 	}
-	if len(rm) > 0 {
-		for _, r := range rm {
+	if len(removed) > 0 {
+		for p, n := range removed {
 			// The file may have been modified locally, in which case it will have been moved to a patch.
 			// So, we just ignore the error here.
-			_ = os.RemoveAll(r)
+			_ = os.RemoveAll(n)
 			if events != nil {
-				rel, err := filepath.Rel(b.cwd, r)
+				rel, err := filepath.Rel(b.cwd, n)
 				if err != nil {
 					return count, err
 				}
 				events <- PathEvent{
 					Path: rel,
 					Type: FileRemoved,
+				}
+			}
+			if b.repo != nil {
+				if err := b.repo.RemovePath(ctx, p); err != nil {
+					return count, err
 				}
 			}
 		}
@@ -196,6 +203,52 @@ looop:
 	return count, nil
 }
 
+func (b *Bucket) diffPath(
+	ctx context.Context,
+	pth, dest string,
+) (diff []Change, missing []object, removed map[string]string, err error) {
+	all, missing, err := b.listPath(ctx, pth, dest, false)
+	if err != nil {
+		return
+	}
+	removed = make(map[string]string)
+	list, err := b.walkPath(dest)
+	if err != nil {
+		return
+	}
+loop:
+	for _, n := range list {
+		for _, r := range all {
+			if r.name == n {
+				continue loop
+			}
+		}
+		p := strings.TrimPrefix(n, dest+string(os.PathSeparator))
+		r, err := filepath.Rel(b.cwd, n)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		diff = append(diff, Change{Type: du.Add, Name: n, Path: p, Rel: r})
+		removed[p] = n
+	}
+	for _, o := range missing {
+		var ct du.ChangeType
+		if _, err = os.Stat(o.name); err == nil {
+			ct = du.Mod
+		} else if os.IsNotExist(err) {
+			ct = du.Remove
+		} else {
+			return
+		}
+		r, err := filepath.Rel(b.cwd, o.name)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		diff = append(diff, Change{Type: ct, Name: o.name, Path: o.path, Rel: r})
+	}
+	return diff, missing, removed, nil
+}
+
 type object struct {
 	path string
 	name string
@@ -203,14 +256,18 @@ type object struct {
 	size int64
 }
 
-func (b *Bucket) listPath(ctx context.Context, key, pth, dest string, force bool) (all, missing []object, err error) {
-	rep, err := b.clients.Buckets.ListPath(ctx, key, pth)
+func (b *Bucket) listPath(
+	ctx context.Context,
+	pth, dest string,
+	force bool,
+) (all, missing []object, err error) {
+	rep, err := b.clients.Buckets.ListPath(ctx, b.Key(), pth)
 	if err != nil {
 		return
 	}
 	if rep.Item.IsDir {
 		for _, i := range rep.Item.Items {
-			a, m, err := b.listPath(ctx, key, filepath.Join(pth, filepath.Base(i.Path)), dest, force)
+			a, m, err := b.listPath(ctx, filepath.Join(pth, filepath.Base(i.Path)), dest, force)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/buckets/local/pull.go
+++ b/buckets/local/pull.go
@@ -7,10 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	du "github.com/ipfs/go-merkledag/dagutils"
-
 	cid "github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
+	du "github.com/ipfs/go-merkledag/dagutils"
 	"github.com/textileio/textile/v2/api/bucketsd/client"
 	"golang.org/x/sync/errgroup"
 )

--- a/buckets/local/push.go
+++ b/buckets/local/push.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ipfs/go-merkledag/dagutils"
+	du "github.com/ipfs/go-merkledag/dagutils"
 	"github.com/ipfs/interface-go-ipfs-core/path"
 	"github.com/textileio/textile/v2/api/bucketsd/client"
 )
@@ -48,7 +48,7 @@ func (b *Bucket) PushLocal(ctx context.Context, opts ...PathOption) (roots Roots
 				return roots, err
 			}
 			p := strings.TrimPrefix(n, bp+string(os.PathSeparator))
-			reset = append(reset, Change{Type: dagutils.Add, Name: n, Path: p, Rel: r})
+			reset = append(reset, Change{Type: du.Add, Name: n, Path: p, Rel: r})
 		}
 		// Add unique additions
 	loop:
@@ -85,7 +85,7 @@ func (b *Bucket) PushLocal(ctx context.Context, opts ...PathOption) (roots Roots
 	key := b.Key()
 	for _, c := range diff {
 		switch c.Type {
-		case dagutils.Mod, dagutils.Add:
+		case du.Mod, du.Add:
 			var added path.Resolved
 			var err error
 			added, xr, err = b.addFile(ctx, key, xr, c, args.force, args.events)
@@ -97,7 +97,7 @@ func (b *Bucket) PushLocal(ctx context.Context, opts ...PathOption) (roots Roots
 					return roots, err
 				}
 			}
-		case dagutils.Remove:
+		case du.Remove:
 			rm = append(rm, c)
 		}
 	}
@@ -109,7 +109,7 @@ func (b *Bucket) PushLocal(ctx context.Context, opts ...PathOption) (roots Roots
 				return roots, err
 			}
 			if b.repo != nil {
-				if err := b.repo.RemovePath(ctx, c.Name); err != nil {
+				if err := b.repo.RemovePath(ctx, c.Path); err != nil {
 					return roots, err
 				}
 			}

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -55,8 +55,10 @@ func Init(baseCmd *cobra.Command) {
 	initCmd.Flags().StringP("name", "n", "", "Bucket name")
 	initCmd.Flags().BoolP("private", "p", false, "Obfuscates files and folders with encryption")
 	initCmd.Flags().String("cid", "", "Bootstrap the bucket with a UnixFS Cid from the IPFS network")
-	initCmd.Flags().BoolP("existing", "e", false, "Initializes from an existing remote bucket if true")
-	initCmd.Flags().Bool("sync", false, "Syncs local state with remote, i.e., discards local changes if true")
+	initCmd.Flags().BoolP("existing", "e", false, "Interactively select an existing remote bucket if true")
+	initCmd.Flags().Bool("soft", false, "Accepts all local changes, including deletions, if true")
+	initCmd.Flags().Bool("hard", false, "Discards all local changes if true")
+	initCmd.Flags().BoolP("yes", "y", false, "Skips the confirmation prompt if true")
 	initCmd.Flags().BoolP("quiet", "q", false, "Write minimal output")
 
 	pushCmd.Flags().BoolP("force", "f", false, "Allows non-fast-forward updates if true")
@@ -65,7 +67,7 @@ func Init(baseCmd *cobra.Command) {
 	pushCmd.Flags().Int64("maxsize", buckMaxSizeMiB, "Max bucket size in MiB")
 
 	pullCmd.Flags().BoolP("force", "f", false, "Force pull all remote files if true")
-	pullCmd.Flags().Bool("hard", false, "Pulls and prunes local changes if true")
+	pullCmd.Flags().Bool("hard", false, "Discards local changes if true")
 	pullCmd.Flags().BoolP("yes", "y", false, "Skips the confirmation prompt if true")
 	pullCmd.Flags().BoolP("quiet", "q", false, "Write minimal output")
 

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -56,6 +56,7 @@ func Init(baseCmd *cobra.Command) {
 	initCmd.Flags().BoolP("private", "p", false, "Obfuscates files and folders with encryption")
 	initCmd.Flags().String("cid", "", "Bootstrap the bucket with a UnixFS Cid from the IPFS network")
 	initCmd.Flags().BoolP("existing", "e", false, "Initializes from an existing remote bucket if true")
+	initCmd.Flags().Bool("sync", false, "Syncs local state with remote, i.e., discards local changes if true")
 	initCmd.Flags().BoolP("quiet", "q", false, "Write minimal output")
 
 	pushCmd.Flags().BoolP("force", "f", false, "Allows non-fast-forward updates if true")

--- a/cmd/buck/cli/init.go
+++ b/cmd/buck/cli/init.go
@@ -25,6 +25,7 @@ A .textile config directory and a seed file will be created in the current worki
 Existing configs will not be overwritten.
 
 Use the '--existing' flag to initialize from an existing remote bucket.
+Use the '--sync' flag with '--existing' to discard local changes. 
 Use the '--cid' flag to initialize from an existing UnixFS DAG.
 `,
 	Args: cobra.ExactArgs(0),
@@ -41,6 +42,8 @@ Use the '--cid' flag to initialize from an existing UnixFS DAG.
 		if existing && chooseExisting {
 			chooseExisting = false // Nothing left to choose
 		}
+		sync, err := c.Flags().GetBool("sync")
+		cmd.ErrCheck(err)
 
 		var xcid cid.Cid
 		xcids, err := c.Flags().GetString("cid")
@@ -155,6 +158,7 @@ Use the '--cid' flag to initialize from an existing UnixFS DAG.
 			local.WithName(name),
 			local.WithPrivate(private),
 			local.WithCid(xcid),
+			local.WithSync(sync),
 			local.WithExistingPathEvents(events))
 		if progress != nil {
 			progress.Stop()

--- a/cmd/buck/cli/pull.go
+++ b/cmd/buck/cli/pull.go
@@ -13,8 +13,12 @@ import (
 var pullCmd = &cobra.Command{
 	Use:   "pull",
 	Short: "Pull bucket object changes",
-	Long:  `Pulls paths that have been added to and paths that have been removed or differ from the remote bucket root.`,
-	Args:  cobra.ExactArgs(0),
+	Long: `Pulls paths that have been added to and paths that have been removed or differ from the remote bucket root.
+
+Use the '--hard' flag to discard all local changes.
+Use the '--force' flag to pull all remote objects, even if they already exist locally.
+`,
+	Args: cobra.ExactArgs(0),
 	Run: func(c *cobra.Command, args []string) {
 		force, err := c.Flags().GetBool("force")
 		cmd.ErrCheck(err)

--- a/cmd/buck/cli/push.go
+++ b/cmd/buck/cli/push.go
@@ -22,8 +22,11 @@ var (
 var pushCmd = &cobra.Command{
 	Use:   "push",
 	Short: "Push bucket object changes",
-	Long:  `Pushes paths that have been added to and paths that have been removed or differ from the local bucket root.`,
-	Args:  cobra.ExactArgs(0),
+	Long: `Pushes paths that have been added to and paths that have been removed or differ from the local bucket root.
+
+Use the '--force' flag to allow a non-fast-forward update.
+`,
+	Args: cobra.ExactArgs(0),
 	Run: func(c *cobra.Command, args []string) {
 		force, err := c.Flags().GetBool("force")
 		cmd.ErrCheck(err)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,7 +53,7 @@ func FindConfigFile(conf *Config, pth string) bool {
 	for h <= maxSearchHeight && !found {
 		found = initConfig(conf.Viper, conf.File, pth, conf.Dir, conf.Name, conf.EnvPre, conf.Global)
 		npth := filepath.Dir(pth)
-		if npth == "/" && pth == "/" {
+		if npth == string(os.PathSeparator) && pth == string(os.PathSeparator) {
 			return found
 		}
 		pth = npth


### PR DESCRIPTION
Tricky one requested by a few different users.

- Adds some more `init` flags. From `buck init --help`:
```
By default, if the remote bucket exists, remote objects are pulled and merged with local changes.
Use the '--soft' flag to accept all local changes, including deletions.
Use the '--hard' flag to discard all local changes.
```