### PR TITLE
update to powergate v2.0.0 official tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/textileio/go-assets v0.0.0-20200430191519-b341e634e2b7
 	github.com/textileio/go-ds-mongo v0.1.5-0.20201230201018-2b7fdca787a5
 	github.com/textileio/go-threads v1.0.3-0.20201216032729-f7b034a0de80
-	github.com/textileio/powergate/v2 v2.0.0-rc3
+	github.com/textileio/powergate/v2 v2.0.0
 	github.com/textileio/uiprogress v0.0.4
 	github.com/xakep666/mongo-migrate v0.2.1
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1735,8 +1735,8 @@ github.com/textileio/go-ds-mongo v0.1.5-0.20201230201018-2b7fdca787a5 h1:wy2WAFw
 github.com/textileio/go-ds-mongo v0.1.5-0.20201230201018-2b7fdca787a5/go.mod h1:Zf6JlMPiIQUUmGlFFn5Z65C9p9LAvPg7XvX+qdGmTsU=
 github.com/textileio/go-threads v1.0.3-0.20201216032729-f7b034a0de80 h1:UJbiLtEmaRp9zUif+thvxsIOkeZnTECIWcaURCBaXS4=
 github.com/textileio/go-threads v1.0.3-0.20201216032729-f7b034a0de80/go.mod h1:kvIXqo4T4fS6fDyNeqRAIE5CXDguBXUi8kZVb4FGg0U=
-github.com/textileio/powergate/v2 v2.0.0-rc3 h1:6Gjud1vVsj5RVTfQrm7Ry+vEyxyDAEZYd+5+bWBU9Tc=
-github.com/textileio/powergate/v2 v2.0.0-rc3/go.mod h1:xC4R25o7VhnFsfNHOIGyK5Qsq/6xy2bZo2Q+uaf2ZtM=
+github.com/textileio/powergate/v2 v2.0.0 h1:OqJLDyJUU46goa1D1M9RzuwYjDPre81ByDNWd9aGfU0=
+github.com/textileio/powergate/v2 v2.0.0/go.mod h1:xC4R25o7VhnFsfNHOIGyK5Qsq/6xy2bZo2Q+uaf2ZtM=
 github.com/textileio/uiprogress v0.0.4 h1:7FWXEKK/h54ssNOW24q9MeJ9Eujptsr8eDPq35aPHjo=
 github.com/textileio/uiprogress v0.0.4/go.mod h1:ijtyLXHP6vw9MbbT4tmCKZonLPE3LN4mD9C/XRJkrgg=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=

--- a/integrationtest/pg/docker-compose.yml
+++ b/integrationtest/pg/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   powergate:
-    image: textile/powergate:v2.0.0-rc3
+    image: textile/powergate:v2.0.0
     ports:
       - "8889:8889"
       - "8888:8888"

--- a/integrationtest/pg/powcli/docker-compose-pow.yml
+++ b/integrationtest/pg/powcli/docker-compose-pow.yml
@@ -47,7 +47,7 @@ services:
       - billing
 
   powergate:
-    image: textile/powergate:v2.0.0-rc3
+    image: textile/powergate:v2.0.0
     depends_on:
       - ipfs
       - ipfsbuckets


### PR DESCRIPTION
This PR updates the Powergate client and docker-images tags to the official v2.0.0 release.