### PR TITLE
feat(buck): extend command existing with the format flag

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -42,7 +42,7 @@ func Success(format string, args ...interface{}) {
 func JSON(data interface{}) {
 	bytes, err := json.MarshalIndent(data, "", "  ")
 	ErrCheck(err)
-	fmt.Println(aurora.BrightBlack(string(bytes)))
+	fmt.Println(string(bytes))
 }
 
 func End(format string, args ...interface{}) {


### PR DESCRIPTION
Add the flag --format. The flag --format accepts a string to define the output format.
Add support for the format 'json'. If the format is set to json the link struct is printed as a parsable JSON object.

