### PR TITLE
feat(buck): add the non interactive flag to the init command

### DIFF
--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -60,6 +60,7 @@ func Init(baseCmd *cobra.Command) {
 	initCmd.Flags().Bool("hard", false, "Discards all local changes if true")
 	initCmd.Flags().BoolP("yes", "y", false, "Skips the confirmation prompt if true")
 	initCmd.Flags().BoolP("quiet", "q", false, "Write minimal output")
+	initCmd.Flags().Bool("non-interactive", false, "Disable interactive prompts")
 	// (jsign): disabled until this feature is usable in mainnet.
 	// initCmd.Flags().Bool("unfreeze", false, "Unfreeze --cid from a known or imported deals in Filecoin.")
 


### PR DESCRIPTION
Add the flag --non-interactive. Foreach interactive option the default value will be used

The `--non-interactive` flag allows the execution of the init command in a headless environment. Like a CI.