### PR TITLE
feat(buck): extend command init with the format flag

### DIFF
--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -60,6 +60,7 @@ func Init(baseCmd *cobra.Command) {
 	initCmd.Flags().Bool("hard", false, "Discards all local changes if true")
 	initCmd.Flags().BoolP("yes", "y", false, "Skips the confirmation prompt if true")
 	initCmd.Flags().BoolP("quiet", "q", false, "Write minimal output")
+	initCmd.Flags().String("format", "default", "Display URL links in the provided format. Options: [default,json]")
 	// (jsign): disabled until this feature is usable in mainnet.
 	// initCmd.Flags().Bool("unfreeze", false, "Unfreeze --cid from a known or imported deals in Filecoin.")
 

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -51,6 +51,7 @@ func Init(baseCmd *cobra.Command) {
 
 	baseCmd.PersistentFlags().String("key", "", "Bucket key")
 	baseCmd.PersistentFlags().String("thread", "", "Thread ID")
+	baseCmd.PersistentFlags().String("format", "default", "Display command output in the provided format. Options: [default,json]")
 
 	initCmd.Flags().StringP("name", "n", "", "Bucket name")
 	initCmd.Flags().BoolP("private", "p", false, "Obfuscates files and folders with encryption")
@@ -83,7 +84,6 @@ func Init(baseCmd *cobra.Command) {
 
 	rolesGrantCmd.Flags().StringP("role", "r", "", "Access role: none, reader, writer, admin")
 
-	linksCmd.Flags().String("format", "default", "Display URL links in the provided format. Options: [default,json]")
 }
 
 func SetBucks(b *local.Buckets) {

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -61,7 +61,6 @@ func Init(baseCmd *cobra.Command) {
 	initCmd.Flags().Bool("hard", false, "Discards all local changes if true")
 	initCmd.Flags().BoolP("yes", "y", false, "Skips the confirmation prompt if true")
 	initCmd.Flags().BoolP("quiet", "q", false, "Write minimal output")
-	initCmd.Flags().String("format", "default", "Display URL links in the provided format. Options: [default,json]")
 	// (jsign): disabled until this feature is usable in mainnet.
 	// initCmd.Flags().Bool("unfreeze", false, "Unfreeze --cid from a known or imported deals in Filecoin.")
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -42,7 +42,7 @@ func Success(format string, args ...interface{}) {
 func JSON(data interface{}) {
 	bytes, err := json.MarshalIndent(data, "", "  ")
 	ErrCheck(err)
-	fmt.Println(aurora.BrightBlack(string(bytes)))
+	fmt.Println(string(bytes))
 }
 
 func End(format string, args ...interface{}) {


### PR DESCRIPTION
Add the flag --format. The flag --format accepts a string to define the output format.
Add support for the format 'json'.