### PR TITLE
docs(hub): fix hub bucket add description

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Usage:
   buck [command]
 
 Available Commands:
-  add         Add adds a UnixFs DAG locally at path
+  add         Add a UnixFs DAG locally at path
   archive     Create a Filecoin archive
   cat         Cat bucket objects at path
   decrypt     Decrypt bucket objects at path with password

--- a/cmd/buck/cli/add.go
+++ b/cmd/buck/cli/add.go
@@ -12,8 +12,8 @@ import (
 
 var addCmd = &cobra.Command{
 	Use:   "add [cid] [path]",
-	Short: "Add adds a UnixFs DAG locally at path",
-	Long:  `Add adds a UnixFs DAG locally at path, merging with existing content.`,
+	Short: "Adds a UnixFs DAG locally at path",
+	Long:  `Adds a UnixFs DAG locally at path, merging with existing content.`,
 	Args:  cobra.ExactArgs(2),
 	Run: func(c *cobra.Command, args []string) {
 		yes, err := c.Flags().GetBool("yes")


### PR DESCRIPTION
Hi folks,

A little typo I think I stumbled upon, the add command is described as `Add adds a UnixFs DAG...` but I think it should say `Adds a UnixFs DAG...` to avoid confusion.

```
Available Commands:
  add         Add adds a UnixFs DAG locally at path
  archive     Create a Filecoin archive
  cat         Cat bucket objects at path
```

Let me know what you think.