### PR TITLE
gateway: use an io.Reader to serve Cid data

### DIFF
--- a/gateway/buckets.go
+++ b/gateway/buckets.go
@@ -86,6 +86,7 @@ func (g *Gateway) renderBucketPath(c *gin.Context, ctx context.Context, threadID
 		contentType, r, err := getContentTypeFromPullPath(ctx, g.buckets, buck.Key, pth)
 		if err != nil {
 			render404(c)
+			return
 		}
 		c.Writer.Header().Set("Content-Type", contentType)
 		io.Copy(c.Writer, r)


### PR DESCRIPTION
Use an `io.Reader` instead of loading all the content in a slice, which can lead to high RAM usage and potential OOM crashes.
The mime detection still works crafting a new reader to return the full output.