### PR TITLE
Threads: bump to 37a104610bac77a5dc74153bcae34fd254871114

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -532,10 +532,10 @@ func NewTextile(ctx context.Context, conf Config, opts ...Option) (*Textile, err
 	}
 	t.gateway.Start()
 
-	// Start pulling threads
-	t.tn.StartPulling()
 	// Start republishing ipns keys
-	t.ipnsm.StartRepublishing(conf.IPNSRepublishSchedule)
+	if err := t.ipnsm.StartRepublishing(conf.IPNSRepublishSchedule); err != nil {
+		return nil, err
+	}
 
 	log.Info("started")
 

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/textileio/dcrypto v0.0.1
 	github.com/textileio/go-assets v0.0.0-20200430191519-b341e634e2b7
 	github.com/textileio/go-ds-mongo v0.1.5-0.20201230201018-2b7fdca787a5
-	github.com/textileio/go-threads v1.0.3-0.20201216032729-f7b034a0de80
+	github.com/textileio/go-threads v1.1.0-rc1.0.20210317163541-37a104610bac
 	github.com/textileio/powergate/v2 v2.3.0
 	github.com/textileio/swagger-ui v0.3.29-0.20210224180244-7d73a7a32fe7
 	github.com/xakep666/mongo-migrate v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1721,8 +1721,8 @@ github.com/textileio/go-ds-badger v0.2.7-0.20201204225019-4ee78c4a40e2/go.mod h1
 github.com/textileio/go-ds-mongo v0.1.4/go.mod h1:Zf6JlMPiIQUUmGlFFn5Z65C9p9LAvPg7XvX+qdGmTsU=
 github.com/textileio/go-ds-mongo v0.1.5-0.20201230201018-2b7fdca787a5 h1:wy2WAFw2u0RAh7Mnlnh7/Hmc9LlSADDHLlPNZQDBvmM=
 github.com/textileio/go-ds-mongo v0.1.5-0.20201230201018-2b7fdca787a5/go.mod h1:Zf6JlMPiIQUUmGlFFn5Z65C9p9LAvPg7XvX+qdGmTsU=
-github.com/textileio/go-threads v1.0.3-0.20201216032729-f7b034a0de80 h1:UJbiLtEmaRp9zUif+thvxsIOkeZnTECIWcaURCBaXS4=
-github.com/textileio/go-threads v1.0.3-0.20201216032729-f7b034a0de80/go.mod h1:kvIXqo4T4fS6fDyNeqRAIE5CXDguBXUi8kZVb4FGg0U=
+github.com/textileio/go-threads v1.1.0-rc1.0.20210317163541-37a104610bac h1:0PWkPfJktzmoiVh3CngKrgx3C9n7m/ttcNrhHt9Su/Y=
+github.com/textileio/go-threads v1.1.0-rc1.0.20210317163541-37a104610bac/go.mod h1:kvIXqo4T4fS6fDyNeqRAIE5CXDguBXUi8kZVb4FGg0U=
 github.com/textileio/powergate/v2 v2.3.0 h1:kelYh+ZWDQao1rL5YiMznQscd6CsDjgt6P/D1S5UYwQ=
 github.com/textileio/powergate/v2 v2.3.0/go.mod h1:2j2NL1oevaVdrI6MpKfHnfgUOy1D4L7eP3I+1czxDjw=
 github.com/textileio/swagger-ui v0.3.29-0.20210224180244-7d73a7a32fe7 h1:qUEurT6kJF+nFkiNjUPMJJ7hgg9OIDnb8iLn6VtBukE=


### PR DESCRIPTION
Bump threads to a temporary branch off of [v1.1.0-rc1](https://github.com/textileio/go-threads/releases/tag/v1.1.0-rc1) that ignores thread pulls: https://github.com/textileio/go-threads/commit/37a104610bac77a5dc74153bcae34fd254871114