### PR TITLE
Enable Filecoin retrievals in Buckets

### DIFF
--- a/api/bucketsd/service.go
+++ b/api/bucketsd/service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -74,6 +75,9 @@ var (
 	baseArchiveStorageConfig = &userPb.StorageConfig{
 		Hot: &userPb.HotConfig{
 			Enabled: false,
+			Ipfs: &userPb.IpfsConfig{
+				AddTimeout: 15 * 60,
+			},
 		},
 		Cold: &userPb.ColdConfig{
 			Enabled: true,
@@ -3150,7 +3154,8 @@ func (s *Service) Archive(ctx context.Context, req *pb.ArchiveRequest) (*pb.Arch
 			return nil, fmt.Errorf("storage-config has set verified deals but the client is unverified")
 		}
 	}
-	log.Debugf("archiving with filecoin config: %#v", storageConfig.Cold.Filecoin)
+	scjson, _ := json.Marshal(storageConfig)
+	log.Debugf("archiving with filecoin config: %s", scjson)
 
 	// Archive pushes the current root Cid to the corresponding user of the bucket.
 	// The behaviour changes depending on different cases, depending on a previous archive.

--- a/api/usersd/service.go
+++ b/api/usersd/service.go
@@ -466,6 +466,9 @@ func (s *Service) ArchivesLs(ctx context.Context, req *pb.ArchivesLsRequest) (*p
 		if err != nil {
 			return nil, fmt.Errorf("getting cid info: %s", err)
 		}
+		if ci.CidInfo.CurrentStorageInfo == nil {
+			continue
+		}
 		props := ci.CidInfo.CurrentStorageInfo.Cold.Filecoin.Proposals
 		ali := &pb.ArchiveLsItem{
 			Cid:  cs.Cid,

--- a/buckets/archive/retrieval/retrieval.go
+++ b/buckets/archive/retrieval/retrieval.go
@@ -615,7 +615,8 @@ func (fr *FilRetrieval) Logs(ctx context.Context, accKey string, jobID string, p
 		if le.Err != nil {
 			return le.Err
 		}
-		ch <- le.Res.LogEntry.Message
+		timestamp := time.Unix(le.Res.LogEntry.Time, 0)
+		ch <- fmt.Sprintf("%s: %s", timestamp.Format("2006-01-02 15:04:05"), le.Res.LogEntry.Message)
 	}
 	return nil
 }

--- a/buckets/archive/tracker/tracker.go
+++ b/buckets/archive/tracker/tracker.go
@@ -278,7 +278,7 @@ func (t *Tracker) trackRetrievalProgress(ctx context.Context, accKey, jid string
 		message = "non-final status"
 		status = archive.TrackedJobStatusExecuting
 	default:
-		return 0, "", fmt.Errorf("unkown storage-job status: %d", res.StorageJob.Status)
+		return 0, "", fmt.Errorf("unknown storage-job status: %d", res.StorageJob.Status)
 	}
 
 	t.jfe <- archive.JobEvent{

--- a/cmd/buck/cli/cli.go
+++ b/cmd/buck/cli/cli.go
@@ -60,8 +60,7 @@ func Init(baseCmd *cobra.Command) {
 	initCmd.Flags().Bool("hard", false, "Discards all local changes if true")
 	initCmd.Flags().BoolP("yes", "y", false, "Skips the confirmation prompt if true")
 	initCmd.Flags().BoolP("quiet", "q", false, "Write minimal output")
-	// (jsign): disabled until this feature is usable in mainnet.
-	// initCmd.Flags().Bool("unfreeze", false, "Unfreeze --cid from a known or imported deals in Filecoin.")
+	initCmd.Flags().Bool("unfreeze", false, "Unfreeze --cid from a known or imported deals in Filecoin.")
 
 	pushCmd.Flags().BoolP("force", "f", false, "Allows non-fast-forward updates if true")
 	pushCmd.Flags().BoolP("yes", "y", false, "Skips the confirmation prompt if true")

--- a/cmd/buck/cli/init.go
+++ b/cmd/buck/cli/init.go
@@ -73,10 +73,8 @@ Use the '--hard' flag to discard all local changes.
 			cmd.Fatal(errors.New("--cid cannot be used with an existing bucket"))
 		}
 
-		// (jsign): re-enable when this feature is usable in mainnet.
-		//unfreeze, err := c.Flags().GetBool("unfreeze")
-		//cmd.ErrCheck(err)
-		var unfreeze bool
+		unfreeze, err := c.Flags().GetBool("unfreeze")
+		cmd.ErrCheck(err)
 		if unfreeze && xcid == cid.Undef {
 			cmd.Fatal(errors.New("--unfreeze requires specifying --cid"))
 		}

--- a/cmd/hub/cli/archives.go
+++ b/cmd/hub/cli/archives.go
@@ -44,7 +44,7 @@ var archivesLsCmd = &cobra.Command{
 }
 
 var archivesImportCmd = &cobra.Command{
-	Use:   "import", // cid [deal-id ...]",
+	Use:   "import cid [deal-id ...]",
 	Short: "Imports a list of active deal-ids from the Filecoin network for a Cid.",
 	Long:  "Imports a list of active deal-ids from the Filecoin network for a Cid. At least one deal-id must be provided. Cids must be UnixFS DAGs.",
 	Args:  cobra.MinimumNArgs(2),

--- a/cmd/hub/cli/cli.go
+++ b/cmd/hub/cli/cli.go
@@ -84,10 +84,8 @@ func Init(rootCmd *cobra.Command) {
 		threadsCmd,
 		filCmd,
 		billingCmd,
-		// (jsign): commenting this CLIs until this feature
-		// is usable in mainnet.
-		// archivesCmd,
-		// retrievalsCmd,
+		archivesCmd,
+		retrievalsCmd,
 	)
 	orgsCmd.AddCommand(orgsCreateCmd, orgsLsCmd, orgsMembersCmd, orgsInviteCmd, orgsLeaveCmd, orgsDestroyCmd)
 	keysCmd.AddCommand(keysCreateCmd, keysInvalidateCmd, keysLsCmd)

--- a/cmd/hub/cli/retrievals.go
+++ b/cmd/hub/cli/retrievals.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -36,6 +37,9 @@ var retrievalsLsCmd = &cobra.Command{
 		cmd.ErrCheck(err)
 
 		if len(rs.Retrievals) > 0 {
+			sort.Slice(rs.Retrievals, func(i, j int) bool {
+				return rs.Retrievals[i].CreatedAt > rs.Retrievals[j].CreatedAt
+			})
 			data := make([][]string, len(rs.Retrievals))
 			for i, r := range rs.Retrievals {
 				data[i] = []string{
@@ -46,6 +50,7 @@ var retrievalsLsCmd = &cobra.Command{
 					r.FailureCause,
 				}
 			}
+
 			cmd.RenderTable([]string{"Id", "Cid", "Status", "Created", "Failure cause"}, data)
 		}
 		cmd.Message("Found %d retrievals", aurora.White(len(rs.Retrievals)).Bold())

--- a/cmd/hubd/main.go
+++ b/cmd/hubd/main.go
@@ -126,7 +126,7 @@ var (
 			},
 			"archivesJobPollIntervalFast": {
 				Key:      "archives.job_poll_interval_fast",
-				DefValue: time.Minute * 15,
+				DefValue: time.Minute * 5,
 			},
 
 			// IPNS

--- a/integrationtest/pg/docker-compose.yml
+++ b/integrationtest/pg/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   powergate:
-    image: textile/powergate:v2.0.0
+    image: textile/powergate:v2.3.2-jsign
     ports:
       - "8889:8889"
       - "8888:8888"

--- a/integrationtest/pg/docker-compose.yml
+++ b/integrationtest/pg/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   powergate:
-    image: textile/powergate:v2.3.2-jsign
+    image: textile/powergate:v2.3.3
     ports:
       - "8889:8889"
       - "8888:8888"
@@ -19,7 +19,7 @@ services:
       - POWD_FFSMINERSELECTOR=reputation
     restart: unless-stopped
   lotus:
-    image: textile/lotus-devnet:v1.4.2
+    image: textile/lotus-devnet:v1.5.2
     environment:
       - TEXLOTUSDEVNET_SPEED=100
       - TEXLOTUSDEVNET_IPFSADDR=/dns4/ipfs/tcp/5001

--- a/integrationtest/pg/pg_test.go
+++ b/integrationtest/pg/pg_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestCreateBucket(t *testing.T) {
-	powc, _ := StartPowergate(t, true)
+	powc, _ := StartPowergate(t)
 	ctx, _, _, _, client, _, shutdown := setup(t)
 	defer shutdown()
 
@@ -61,7 +61,7 @@ func TestCreateBucket(t *testing.T) {
 
 func TestArchiveTracker(t *testing.T) {
 	util.RunFlaky(t, func(t *util.FlakyT) {
-		_, _ = StartPowergate(t, true)
+		_, _ = StartPowergate(t)
 		ctx, conf, _, _, client, repo, shutdown := setup(t)
 
 		// Create bucket with a file.
@@ -107,7 +107,7 @@ func TestArchiveTracker(t *testing.T) {
 
 func TestArchiveBucketWorkflow(t *testing.T) {
 	util.RunFlaky(t, func(t *util.FlakyT) {
-		_, _ = StartPowergate(t, true)
+		_, _ = StartPowergate(t)
 		ctx, _, _, usersClient, buckClient, _, shutdown := setup(t)
 		defer shutdown()
 
@@ -172,7 +172,7 @@ func TestArchiveBucketWorkflow(t *testing.T) {
 
 func TestArchivesLs(t *testing.T) {
 	util.RunFlaky(t, func(t *util.FlakyT) {
-		_, _ = StartPowergate(t, true)
+		_, _ = StartPowergate(t)
 		ctx, _, _, usersClient, buckClient, _, shutdown := setup(t)
 		defer shutdown()
 
@@ -239,7 +239,7 @@ func TestArchivesLs(t *testing.T) {
 
 func TestArchivesImport(t *testing.T) {
 	util.RunFlaky(t, func(t *util.FlakyT) {
-		_, _ = StartPowergate(t, true)
+		_, _ = StartPowergate(t)
 		hubClient, usersClient, threadsclient, buckClient, conf, _, shutdown := createInfra(t)
 		defer shutdown()
 
@@ -285,7 +285,7 @@ func TestArchivesImport(t *testing.T) {
 
 func TestArchiveUnfreeze(t *testing.T) {
 	util.RunFlaky(t, func(t *util.FlakyT) {
-		_, ipfsPow := StartPowergate(t, false)
+		_, ipfsPow := StartPowergate(t)
 		hubClient, usersClient, threadsclient, client, conf, _, shutdown := createInfra(t)
 		defer shutdown()
 		// Create an archive for account-1.
@@ -294,11 +294,6 @@ func TestArchiveUnfreeze(t *testing.T) {
 		require.NoError(t, err)
 		time.Sleep(4 * time.Second) // Give a sec to fund the Fil address.
 		rootCid1 := addDataFileToBucket(ctxAccount1, t, client, buck.Root.Key, "Data1.txt")
-
-		// <LOTUS-BUG-HACK>
-		ccid2, _ := cid.Decode(rootCid1)
-		err = ipfsPow.Pin().Add(context.Background(), path.IpldPath(ccid2))
-		// </LOTUS-BUG-HACK>
 
 		err = client.Archive(ctxAccount1, buck.Root.Key)
 		require.NoError(t, err)
@@ -332,10 +327,6 @@ func TestArchiveUnfreeze(t *testing.T) {
 		// we'll delete now the archive bucket data from both go-ipfs nodes (Hub's
 		// and Powergate).
 		ctx := context.Background()
-
-		// <LOTUS-BUG-HACK>
-		err = ipfsPow.Pin().Rm(context.Background(), path.IpldPath(ccid2), options.Pin.RmRecursive(true))
-		// </LOTUS-BUG-HACK>
 
 		err = ipfsPow.Dag().Remove(context.Background(), ccid)
 		require.NoError(t, err)
@@ -411,7 +402,7 @@ func TestArchiveUnfreeze(t *testing.T) {
 
 func TestArchiveWatch(t *testing.T) {
 	util.RunFlaky(t, func(t *util.FlakyT) {
-		_, _ = StartPowergate(t, true)
+		_, _ = StartPowergate(t)
 		ctx, _, _, _, client, _, shutdown := setup(t)
 		defer shutdown()
 
@@ -445,7 +436,7 @@ func TestArchiveWatch(t *testing.T) {
 
 func TestFailingArchive(t *testing.T) {
 	util.RunFlaky(t, func(t *util.FlakyT) {
-		_, _ = StartPowergate(t, true)
+		_, _ = StartPowergate(t)
 		ctx, _, _, _, client, _, shutdown := setup(t)
 		defer shutdown()
 

--- a/integrationtest/pg/pow_client_test.go
+++ b/integrationtest/pg/pow_client_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPowClient(t *testing.T) {
-	_, _ = StartPowergate(t, true)
+	_, _ = StartPowergate(t)
 	ctx, _, client := setupPowClient(t)
 
 	t.Run("Addresses", func(t *testing.T) {

--- a/integrationtest/pg/powergate.go
+++ b/integrationtest/pg/powergate.go
@@ -20,8 +20,8 @@ import (
 var powAddr = "127.0.0.1:5002"
 var ipfsAddr = "/ip4/127.0.0.1/tcp/5022"
 
-func StartPowergate(t util.TestingTWithCleanup, onlineMode bool) (*pc.Client, *httpapi.HttpApi) {
-	os.Setenv("LOTUS_ONLINEMODE", strconv.FormatBool(onlineMode))
+func StartPowergate(t util.TestingTWithCleanup) (*pc.Client, *httpapi.HttpApi) {
+	os.Setenv("LOTUS_ONLINEMODE", strconv.FormatBool(false))
 	_, currentFilePath, _, _ := runtime.Caller(0)
 	dirpath := path.Dir(currentFilePath)
 

--- a/threaddb/buckets.go
+++ b/threaddb/buckets.go
@@ -269,14 +269,14 @@ func (b *Bucket) Copy() *Bucket {
 		ar.History[i] = copyArchives(j)
 	}
 	return &Bucket{
-		Key: b.Key,
-		Owner: b.Owner,
-		Name: b.Name,
-		Version: b.Version,
-		LinkKey: b.LinkKey,
-		Path: b.Path,
-		Metadata: md,
-		Archives: ar,
+		Key:       b.Key,
+		Owner:     b.Owner,
+		Name:      b.Name,
+		Version:   b.Version,
+		LinkKey:   b.LinkKey,
+		Path:      b.Path,
+		Metadata:  md,
+		Archives:  ar,
 		CreatedAt: b.CreatedAt,
 		UpdatedAt: b.UpdatedAt,
 	}
@@ -284,7 +284,7 @@ func (b *Bucket) Copy() *Bucket {
 
 func copyArchives(archive Archive) Archive {
 	a := Archive{
-		Cid: archive.Cid,
+		Cid:   archive.Cid,
 		Deals: make([]Deal, len(archive.Deals)),
 	}
 	for i, j := range archive.Deals {
@@ -626,7 +626,8 @@ func (b *Buckets) ArchiveWatch(ctx context.Context, key string, powToken string,
 		if le.Err != nil {
 			return le.Err
 		}
-		ch <- le.Res.LogEntry.Message
+		timestamp := time.Unix(le.Res.LogEntry.Time, 0)
+		ch <- fmt.Sprintf("%s: %s", timestamp.Format("2006-01-02 15:04:05"), le.Res.LogEntry.Message)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR sits on top of https://github.com/textileio/powergate/pull/807

We had this feature hidden because of a [problem](https://github.com/filecoin-project/lotus/issues/5361) when configuring Lotus when using `IpfsOnlineMode=true`, which didn't make retrievals possible. The Powergate PR workaround this problem, and unblocks the feature.

This PR also added some extra fixes and sections in the Miner Index CLI.