### PR TITLE
hub: fix update cmd when build not available

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -20,35 +20,35 @@ BUF := $(GOBIN)/buf-v0.20.5
 $(BUF): .bingo/buf.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
 	@echo "(re)installing $(GOBIN)/buf-v0.20.5"
-	@cd .bingo && $(GO) build -modfile=buf.mod -o=$(GOBIN)/buf-v0.20.5 "github.com/bufbuild/buf/cmd/buf"
+	@cd .bingo && $(GO) build -mod=mod -modfile=buf.mod -o=$(GOBIN)/buf-v0.20.5 "github.com/bufbuild/buf/cmd/buf"
 
 GOMPLATE := $(GOBIN)/gomplate-v3.8.0
 $(GOMPLATE): .bingo/gomplate.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
 	@echo "(re)installing $(GOBIN)/gomplate-v3.8.0"
-	@cd .bingo && $(GO) build -modfile=gomplate.mod -o=$(GOBIN)/gomplate-v3.8.0 "github.com/hairyhenderson/gomplate/v3/cmd/gomplate"
+	@cd .bingo && $(GO) build -mod=mod -modfile=gomplate.mod -o=$(GOBIN)/gomplate-v3.8.0 "github.com/hairyhenderson/gomplate/v3/cmd/gomplate"
 
 GOVVV := $(GOBIN)/govvv-v0.3.0
 $(GOVVV): .bingo/govvv.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
 	@echo "(re)installing $(GOBIN)/govvv-v0.3.0"
-	@cd .bingo && $(GO) build -modfile=govvv.mod -o=$(GOBIN)/govvv-v0.3.0 "github.com/ahmetb/govvv"
+	@cd .bingo && $(GO) build -mod=mod -modfile=govvv.mod -o=$(GOBIN)/govvv-v0.3.0 "github.com/ahmetb/govvv"
 
 GOX := $(GOBIN)/gox-v1.0.1
 $(GOX): .bingo/gox.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
 	@echo "(re)installing $(GOBIN)/gox-v1.0.1"
-	@cd .bingo && $(GO) build -modfile=gox.mod -o=$(GOBIN)/gox-v1.0.1 "github.com/mitchellh/gox"
+	@cd .bingo && $(GO) build -mod=mod -modfile=gox.mod -o=$(GOBIN)/gox-v1.0.1 "github.com/mitchellh/gox"
 
 PROTOC_GEN_BUF_CHECK_BREAKING := $(GOBIN)/protoc-gen-buf-check-breaking-v0.20.5
 $(PROTOC_GEN_BUF_CHECK_BREAKING): .bingo/protoc-gen-buf-check-breaking.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
 	@echo "(re)installing $(GOBIN)/protoc-gen-buf-check-breaking-v0.20.5"
-	@cd .bingo && $(GO) build -modfile=protoc-gen-buf-check-breaking.mod -o=$(GOBIN)/protoc-gen-buf-check-breaking-v0.20.5 "github.com/bufbuild/buf/cmd/protoc-gen-buf-check-breaking"
+	@cd .bingo && $(GO) build -mod=mod -modfile=protoc-gen-buf-check-breaking.mod -o=$(GOBIN)/protoc-gen-buf-check-breaking-v0.20.5 "github.com/bufbuild/buf/cmd/protoc-gen-buf-check-breaking"
 
 PROTOC_GEN_BUF_CHECK_LINT := $(GOBIN)/protoc-gen-buf-check-lint-v0.20.5
 $(PROTOC_GEN_BUF_CHECK_LINT): .bingo/protoc-gen-buf-check-lint.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
 	@echo "(re)installing $(GOBIN)/protoc-gen-buf-check-lint-v0.20.5"
-	@cd .bingo && $(GO) build -modfile=protoc-gen-buf-check-lint.mod -o=$(GOBIN)/protoc-gen-buf-check-lint-v0.20.5 "github.com/bufbuild/buf/cmd/protoc-gen-buf-check-lint"
+	@cd .bingo && $(GO) build -mod=mod -modfile=protoc-gen-buf-check-lint.mod -o=$(GOBIN)/protoc-gen-buf-check-lint-v0.20.5 "github.com/bufbuild/buf/cmd/protoc-gen-buf-check-lint"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: checkout
         uses: actions/checkout@v1
       - name: build
@@ -40,7 +40,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: checkout
         uses: actions/checkout@v1
       - name: build
@@ -52,7 +52,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: checkout
         uses: actions/checkout@v1
       - name: build
@@ -64,7 +64,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: checkout
         uses: actions/checkout@v1
       - name: build
@@ -76,7 +76,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: checkout
         uses: actions/checkout@v1
       - name: build

--- a/.github/workflows/publish-js-libs.yml
+++ b/.github/workflows/publish-js-libs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup env
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code
         uses: actions/checkout@v1
       - name: Cache dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: checkout
         uses: actions/checkout@v1
       - name: test
@@ -53,7 +53,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: checkout
         uses: actions/checkout@v1
       - name: test
@@ -69,7 +69,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: checkout
         uses: actions/checkout@v1
       - name: test
@@ -92,7 +92,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: checkout
         uses: actions/checkout@v1
       - name: test

--- a/Makefile
+++ b/Makefile
@@ -80,23 +80,23 @@ define gen_release_files
 endef
 
 build-hub-release: $(GOX) $(GOVVV) $(GOMPLATE)
-	$(call gen_release_files,./cmd/hub,hub,"linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64")
+	$(call gen_release_files,./cmd/hub,hub,"linux/amd64 linux/386 linux/arm darwin/amd64 darwin/arm64 windows/amd64")
 .PHONY: build-hub-release
 
 build-hubd-release: $(GOX) $(GOVVV) $(GOMPLATE)
-	$(call gen_release_files,./cmd/hubd,hubd,"linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64")
+	$(call gen_release_files,./cmd/hubd,hubd,"linux/amd64 linux/386 linux/arm darwin/amd64 darwin/arm64 windows/amd64")
 .PHONY: build-hubd-release
 
 build-buck-release: $(GOX) $(GOVVV) $(GOMPLATE)
-	$(call gen_release_files,./cmd/buck,buck,"linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64")
+	$(call gen_release_files,./cmd/buck,buck,"linux/amd64 linux/386 linux/arm darwin/amd64 darwin/arm64 windows/amd64")
 .PHONY: build-buck-release
 
 build-buckd-release: $(GOX) $(GOVVV) $(GOMPLATE)
-	$(call gen_release_files,./cmd/buckd,buckd,"linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64")
+	$(call gen_release_files,./cmd/buckd,buckd,"linux/amd64 linux/386 linux/arm darwin/amd64 darwin/arm64 windows/amd64")
 .PHONY: build-buckd-release
 
 build-billingd-release: $(GOX) $(GOVVV) $(GOMPLATE)
-	$(call gen_release_files,./api/billingd,billingd,"linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64")
+	$(call gen_release_files,./api/billingd,billingd,"linux/amd64 linux/386 linux/arm darwin/amd64 darwin/arm64 windows/amd64")
 .PHONY: build-billingd-release
 
 build-releases: build-hub-release build-hubd-release build-buck-release build-buckd-release build-billingd-release

--- a/api/billingd/Dockerfile
+++ b/api/billingd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-buster
+FROM golang:1.16.0-buster
 MAINTAINER Textile <contact@textile.io>
 
 # This is (in large part) copied (with love) from

--- a/api/billingd/Dockerfile.dev
+++ b/api/billingd/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-buster
+FROM golang:1.16.0-buster
 
 RUN apt-get update && apt-get install -y \
   libssl-dev \

--- a/api/mindexd/Dockerfile
+++ b/api/mindexd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-buster
+FROM golang:1.16.0-buster
 MAINTAINER Textile <contact@textile.io>
 
 # This is (in large part) copied (with love) from

--- a/api/mindexd/Dockerfile.dev
+++ b/api/mindexd/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-buster
+FROM golang:1.16.0-buster
 
 RUN apt-get update && apt-get install -y \
   libssl-dev \

--- a/cmd/buck/cli/archive.go
+++ b/cmd/buck/cli/archive.go
@@ -225,16 +225,16 @@ var archiveCmd = &cobra.Command{
 		addrs, err := buck.Addresses(ctx)
 		cmd.ErrCheck(err)
 		if len(addrs.Addresses) != 1 {
-			cmd.Error(fmt.Errorf("There should be exactly one wallet address but there are %d", len(addrs.Addresses)))
+			cmd.Fatal(fmt.Errorf("There should be exactly one wallet address but there are %d", len(addrs.Addresses)))
 		}
 
 		addrInfo := addrs.Addresses[0]
 		balance, ok := big.NewInt(0).SetString(addrInfo.Balance, 10)
 		if !ok {
-			cmd.Error(fmt.Errorf("parsing current balance"))
+			cmd.Fatal(fmt.Errorf("parsing current balance"))
 		}
 		if balance.Cmp(big.NewInt(0)) == 0 {
-			cmd.Error(fmt.Errorf("The wallet address balance is zero, you'll need to add some funds!"))
+			cmd.Fatal(fmt.Errorf("The wallet address balance is zero, you'll need to add some funds!"))
 		}
 
 		skipVerifiedDealOverride, err := c.Flags().GetBool("skip-verified-deal-override")
@@ -243,7 +243,7 @@ var archiveCmd = &cobra.Command{
 			if !config.VerifiedDeal && addrInfo.VerifiedClientInfo != nil {
 				remainingDataCap, ok := big.NewInt(0).SetString(addrInfo.VerifiedClientInfo.RemainingDatacapBytes, 10)
 				if !ok {
-					cmd.Error(fmt.Errorf("Parsing remaining datacap"))
+					cmd.Fatal(fmt.Errorf("Parsing remaining datacap"))
 				}
 				if remainingDataCap.Cmp(big.NewInt(0)) > 0 {
 					// If the default storage-config is !verified-deal, but the client

--- a/cmd/buck/cli/roles.go
+++ b/cmd/buck/cli/roles.go
@@ -62,7 +62,7 @@ Access roles:
 		}
 		role, err := buckets.NewRoleFromString(roleStr)
 		if err != nil {
-			cmd.Error(fmt.Errorf("access role must be one of: none, reader, writer, or admin"))
+			cmd.Fatal(fmt.Errorf("access role must be one of: none, reader, writer, or admin"))
 		}
 		var pth string
 		if len(args) > 1 {

--- a/cmd/buckd/Dockerfile
+++ b/cmd/buckd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-buster
+FROM golang:1.16.0-buster
 MAINTAINER Textile <contact@textile.io>
 
 # This is (in large part) copied (with love) from

--- a/cmd/buckd/Dockerfile.dev
+++ b/cmd/buckd/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-buster
+FROM golang:1.16.0-buster
 
 RUN apt-get update
 

--- a/cmd/hubd/Dockerfile
+++ b/cmd/hubd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-buster
+FROM golang:1.16.0-buster
 MAINTAINER Textile <contact@textile.io>
 
 # This is (in large part) copied (with love) from

--- a/cmd/hubd/Dockerfile.dev
+++ b/cmd/hubd/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-buster
+FROM golang:1.16.0-buster
 
 RUN apt-get update
 

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -14,7 +14,7 @@ import (
 type WatchState struct {
 	// State of the watch connection (online/offline).
 	State ConnectionState
-	// Error returned by the watch operation.
+	// Err returned by the watch operation.
 	Err error
 	// Aborted indicates whether or not the associated error aborted the watch.
 	// (Connectivity related errors do not abort the watch.)

--- a/ipns/ipns.go
+++ b/ipns/ipns.go
@@ -255,6 +255,6 @@ func (m *Manager) republish() error {
 		return err
 	}
 
-	log.Infof("republished %d/%d keys in %v", len(keys), withPath, time.Since(start))
+	log.Infof("republished %d/%d keys in %v", withPath, len(keys), time.Since(start))
 	return nil
 }


### PR DESCRIPTION
`hub update` was panicing on my M1 machine because the code here was assuming the release would always be available for current os/arch. I got sucked into some more improvements. 

I spent a little time actually adding the arm64 builds, but ran into an issue with bingo on go 1.16 and some random build errors while testing locally:
```
--> darwin/arm64 error: exit status 2
Stderr: # github.com/textileio/textile/v2/cmd/hub
/usr/local/go/pkg/tool/darwin_amd64/link: running clang failed: exit status 1
ld: warning: ignoring file /var/folders/bp/7ygrmpvn1779kd81k0ltmqkm0000gn/T/go-link-502520635/go.o, building for macOS-x86_64 but attempting to link with file built for unknown-arm64
Undefined symbols for architecture x86_64:
  "_main", referenced from:
     implicit entry/start for main executable
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Will resume when other things are less pressing. 