### PR TITLE
hub: fix typo in apisecret lookup

### DIFF
--- a/cmd/hub/cli/cli.go
+++ b/cmd/hub/cli/cli.go
@@ -138,7 +138,7 @@ func Auth(ctx context.Context) context.Context {
 			ctx, err = common.CreateAPISigContext(
 				ctx,
 				time.Now().Add(time.Hour),
-				config.Viper.GetString("secret"),
+				config.Viper.GetString("apiSecret"),
 			)
 			if err != nil {
 				cmd.Fatal(fmt.Errorf("invalid secret: %w", err))


### PR DESCRIPTION
Fixes `apiSecret` key lookup from the viper config.

There are three ways to leverage config values:

1. Flags

```
hub --apiKey=<key> --apiSecret=<secret> threads ls
```

2. Config file

```
api: api.hub.textile.io:443
apiKey: <key>
apiSecret: <secret>
org: <org> // not required
```

3. Environment vars

```
env HUB_APIKEY=<key> HUB_APISECRET=<secret> hub threads ls
```

Viper [lowercases config keys](https://github.com/spf13/viper/blob/master/viper.go#L1079) when binding to env vars, e.g., the var for api secret is `HUB_APISECRET`, not `HUB_API_SECRET`.

This is confusing because in other program configs we are mapping flags to nested config value. Here's an example from `hubd`:

```
"addrApi": {
    Key:      "addr.api",
    DefValue: "/ip4/127.0.0.1/tcp/3006",
},
```
That will map to an env var of `HUB_ADDR_API` due to the use of `.` in `Key`. We could update the `hub` CLI to use nested config values, or just provide better document for the env vars. Personally, I like the use of a single level (not nested) config file for `hub`, but open to opinions.