### PR TITLE
fix(css): adds ext detection back for css

### DIFF
--- a/gateway/buckets.go
+++ b/gateway/buckets.go
@@ -281,7 +281,7 @@ func getContentTypeFromPullPath(ctx context.Context, client *bucketsclient.Clien
 		}
 	}()
 
-	contentType, r, err := detectReaderContentType(pr)
+	contentType, r, err := detectReaderContentType(pr, pth)
 	if err != nil {
 		return "", nil, fmt.Errorf("detecting content-type: %s", err)
 	}

--- a/gateway/ipfs.go
+++ b/gateway/ipfs.go
@@ -101,7 +101,7 @@ func (g *Gateway) renderIPFSPath(c *gin.Context, base, pth string) {
 
 // detectReaderContentType detects the best available mime type for some bytes.
 // Note: file extension is used here due to the inability to detect some known
-// content types from extension alone, those include CSS.
+// content types from content alone, those include CSS.
 func detectReaderContentType(r io.Reader, pth string) (string, io.Reader, error) {
 	var buf [512]byte
 	n, err := io.ReadAtLeast(r, buf[:], len(buf))

--- a/gateway/ipfs.go
+++ b/gateway/ipfs.go
@@ -99,6 +99,9 @@ func (g *Gateway) renderIPFSPath(c *gin.Context, base, pth string) {
 	c.Render(200, render.Reader{ContentLength: -1, Reader: r})
 }
 
+// detectReaderContentType detects the best available mime type for some bytes.
+// Note: file extension is used here due to the inability to detect some known
+// content types from extension alone, those include CSS.
 func detectReaderContentType(r io.Reader, pth string) (string, io.Reader, error) {
 	var buf [512]byte
 	n, err := io.ReadAtLeast(r, buf[:], len(buf))


### PR DESCRIPTION
Signed-off-by: Andrew Hill <andrew@textile.io>

based on the suggestion here https://forum.golangbridge.org/t/detectcontenttype-return-wrong-content-type/2922

not comprehensive in any way, just trying to fix incorrect CSS handling in firefox