### PR TITLE
Docker Github action matrix imageRepo fix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,13 +14,13 @@ jobs:
           - textile/buckets
           - textile/mindexd
         include:
-          - package: textile/hub
+          - imageRepo: textile/hub
             dockerFile: cmd/hubd/Dockerfile
-          - package: textile/billing
+          - imageRepo: textile/billing
             dockerFile: api/billingd/Dockerfile
-          - package: textile/buckets
+          - imageRepo: textile/buckets
             dockerFile: cmd/buckd/Dockerfile
-          - package: textile/mindexd
+          - imageRepo: textile/mindexd
             dockerFile: api/mindexd/Dockerfile
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The matrix list name, `imageRepo` in this case, must match a field in the includes. Otherwise, it just uses 1 value for all iterations.

Signed-off-by: Ben Wilson <ben@textile.io>