### PR TITLE
Old Bucket Archive Fixes

### DIFF
--- a/api/bucketsd/service.go
+++ b/api/bucketsd/service.go
@@ -3202,7 +3202,7 @@ func (s *Service) Archive(ctx context.Context, req *pb.ArchiveRequest) (*pb.Arch
 			case userPb.JobStatus_JOB_STATUS_EXECUTING, userPb.JobStatus_JOB_STATUS_QUEUED:
 				return nil, fmt.Errorf("there is an in progress archive")
 			// Case 1.c.
-			case userPb.JobStatus_JOB_STATUS_FAILED, userPb.JobStatus_JOB_STATUS_CANCELED:
+			case userPb.JobStatus_JOB_STATUS_FAILED, userPb.JobStatus_JOB_STATUS_CANCELED, userPb.JobStatus_JOB_STATUS_UNSPECIFIED:
 				res, err := s.PowergateClient.StorageConfig.Apply(
 					ctxPow,
 					p.Cid().String(),

--- a/api/bucketsd/service.go
+++ b/api/bucketsd/service.go
@@ -3202,7 +3202,7 @@ func (s *Service) Archive(ctx context.Context, req *pb.ArchiveRequest) (*pb.Arch
 			case userPb.JobStatus_JOB_STATUS_EXECUTING, userPb.JobStatus_JOB_STATUS_QUEUED:
 				return nil, fmt.Errorf("there is an in progress archive")
 			// Case 1.c.
-			case userPb.JobStatus_JOB_STATUS_FAILED, userPb.JobStatus_JOB_STATUS_CANCELED, userPb.JobStatus_JOB_STATUS_UNSPECIFIED:
+			case userPb.JobStatus_JOB_STATUS_FAILED, userPb.JobStatus_JOB_STATUS_CANCELED:
 				res, err := s.PowergateClient.StorageConfig.Apply(
 					ctxPow,
 					p.Cid().String(),

--- a/api/bucketsd/service.go
+++ b/api/bucketsd/service.go
@@ -3218,11 +3218,12 @@ func (s *Service) Archive(ctx context.Context, req *pb.ArchiveRequest) (*pb.Arch
 			}
 		} else { // Case 2.
 			res, err := s.PowergateClient.Data.CidInfo(ctxPow, oldCid.String())
-			if err != nil {
+			isKnownToPowergate := err == nil || status.Convert(err).Code() != codes.NotFound
+			if err != nil && isKnownToPowergate {
 				return nil, fmt.Errorf("looking up old storage config: %v", err)
 			}
 
-			if cmp.Equal(&storageConfig, res.CidInfo.LatestPushedStorageConfig) {
+			if isKnownToPowergate && cmp.Equal(&storageConfig, res.CidInfo.LatestPushedStorageConfig) {
 				// Old storage config is the same as the new so use replace.
 				res, err := s.PowergateClient.Data.ReplaceData(ctxPow, oldCid.String(), p.Cid().String())
 				if err != nil {
@@ -3230,20 +3231,24 @@ func (s *Service) Archive(ctx context.Context, req *pb.ArchiveRequest) (*pb.Arch
 				}
 				jid = res.JobId
 			} else {
-				// New storage config, so remove and push.
-				_, err = s.PowergateClient.StorageConfig.Apply(
-					ctxPow,
-					oldCid.String(),
-					pow.WithStorageConfig(&userPb.StorageConfig{}),
-					pow.WithOverride(true),
-				)
-				if err != nil {
-					return nil, fmt.Errorf("pushing config to disable hot and cold storage: %v", err)
+				// New storage config.
+				if isKnownToPowergate {
+					// Remove previous storage config.
+					_, err = s.PowergateClient.StorageConfig.Apply(
+						ctxPow,
+						oldCid.String(),
+						pow.WithStorageConfig(&userPb.StorageConfig{}),
+						pow.WithOverride(true),
+					)
+					if err != nil {
+						return nil, fmt.Errorf("pushing config to disable hot and cold storage: %v", err)
+					}
+					_, err = s.PowergateClient.StorageConfig.Remove(ctxPow, oldCid.String())
+					if err != nil {
+						return nil, fmt.Errorf("removing old cid storage: %v", err)
+					}
 				}
-				_, err = s.PowergateClient.StorageConfig.Remove(ctxPow, oldCid.String())
-				if err != nil {
-					return nil, fmt.Errorf("removing old cid storage: %v", err)
-				}
+				// Push new storage config.
 				res, err := s.PowergateClient.StorageConfig.Apply(
 					ctxPow,
 					p.Cid().String(),

--- a/mongodb/bucketarchives.go
+++ b/mongodb/bucketarchives.go
@@ -36,7 +36,7 @@ type DealInfo struct {
 	Miner       string `bson:"miner"`
 
 	PieceCID string `bson:"piece_cid"`
-	Size     uint64
+	Size     uint64 `bson:"size"`
 
 	PricePerEpoch uint64 `bson:"price_per_epoch"`
 	StartEpoch    uint64 `bson:"start_epoch"`

--- a/mongodb/migrations/migrations_test.go
+++ b/mongodb/migrations/migrations_test.go
@@ -183,6 +183,176 @@ func TestMigrations_m004(t *testing.T) {
 	assert.Nil(t, key2["path"])
 }
 
+func TestMigrations_m005(t *testing.T) {
+	ctx := context.Background()
+	db := setup(t, ctx)
+	_, err := db.Collection("bucketarchives").InsertMany(ctx, []interface{}{
+		bson.M{
+			"_id": "id1",
+			"archives": bson.M{
+				"current": bson.M{
+					"job_id":     "job3",
+					"status":     1,
+					"created_at": 1000,
+				},
+				"history": bson.A{
+					bson.M{
+						"job_id":     "job2",
+						"status":     1,
+						"created_at": 1000,
+					},
+					bson.M{
+						"job_id":     "job1",
+						"status":     1,
+						"created_at": 1000,
+					},
+				},
+			},
+		},
+		bson.M{
+			"_id": "id2",
+			"archives": bson.M{
+				"current": bson.M{
+					"job_id":     "job6",
+					"job_status": 1,
+					"created_at": 1000,
+				},
+				"history": bson.A{
+					bson.M{
+						"job_id":     "job5",
+						"job_status": 1,
+						"created_at": 1000,
+					},
+					bson.M{
+						"job_id":     "job4",
+						"job_status": 1,
+						"created_at": 1000,
+					},
+				},
+			},
+		},
+		bson.M{
+			"_id": "id3",
+			"archives": bson.M{
+				"current": bson.M{
+					"job_id":     "job9",
+					"status":     1,
+					"created_at": 1000,
+				},
+				"history": bson.A{
+					bson.M{
+						"job_id":     "job8",
+						"job_status": 1,
+						"created_at": 1000,
+					},
+					bson.M{
+						"job_id":     "job7",
+						"status":     1,
+						"created_at": 1000,
+					},
+				},
+			},
+		},
+		bson.M{
+			"_id": "id4",
+			"archives": bson.M{
+				"current": bson.M{
+					"job_id":     "job12",
+					"job_status": 1,
+					"created_at": 1000,
+				},
+				"history": bson.A{
+					bson.M{
+						"job_id":     "job11",
+						"status":     1,
+						"created_at": 1000,
+					},
+					bson.M{
+						"job_id":     "job10",
+						"status":     1,
+						"created_at": 1000,
+					},
+				},
+			},
+		},
+		bson.M{
+			"_id": "id5",
+			"archives": bson.M{
+				"history": bson.A{
+					bson.M{
+						"job_id":     "job14",
+						"job_status": 1,
+						"created_at": 1000,
+					},
+					bson.M{
+						"job_id":     "job13",
+						"status":     1,
+						"created_at": 1000,
+					},
+				},
+			},
+		},
+		bson.M{
+			"_id": "id6",
+			"archives": bson.M{
+				"current": bson.M{
+					"job_id":     "job15",
+					"job_status": 1,
+					"created_at": 1000,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Run up
+	err = migrate.NewMigrate(db, m005).Up(migrate.AllAvailable)
+	require.NoError(t, err)
+
+	count, err := db.Collection("bucketarchives").CountDocuments(ctx, bson.M{})
+	require.NoError(t, err)
+	assert.Equal(t, 6, int(count))
+	cursor, err := db.Collection("bucketarchives").Find(ctx, bson.M{})
+	require.NoError(t, err)
+	defer cursor.Close(ctx)
+
+	validateItem := func(item bson.M) {
+		require.NotEmpty(t, item["job_id"])
+		require.Contains(t, item["job_id"], "job")
+		require.Equal(t, 1000, int(item["created_at"].(int32)))
+		require.Nil(t, item["job_status"])
+		require.Equal(t, 1, int(item["status"].(int32)))
+	}
+
+	for cursor.Next(ctx) {
+		var item bson.M
+		require.NoError(t, cursor.Decode(&item))
+		require.NotEmpty(t, item["_id"])
+		require.NotEmpty(t, item["archives"])
+		if item["_id"] == "id1" || item["_id"] == "id2" || item["_id"] == "id3" || item["_id"] == "id4" {
+			require.NotNil(t, item["archives"].(bson.M)["current"])
+			require.NotNil(t, item["archives"].(bson.M)["history"])
+		}
+		if item["_id"] == "id5" {
+			require.Nil(t, item["archives"].(bson.M)["current"])
+			require.NotNil(t, item["archives"].(bson.M)["history"])
+		}
+		if item["_id"] == "id6" {
+			require.NotNil(t, item["archives"].(bson.M)["current"])
+			require.Nil(t, item["archives"].(bson.M)["history"])
+		}
+		if item["archives"].(bson.M)["current"] != nil {
+			validateItem(item["archives"].(bson.M)["current"].(bson.M))
+		}
+		if item["archives"].(bson.M)["history"] != nil {
+			for _, item := range item["archives"].(bson.M)["history"].(bson.A) {
+				validateItem(item.(bson.M))
+			}
+		}
+	}
+	require.NoError(t, cursor.Err())
+}
+
 func setup(t *testing.T, ctx context.Context) *mongo.Database {
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(test.GetMongoUri()))
 	require.NoError(t, err)


### PR DESCRIPTION
Took over this PR to implement the actual fixes for the following issues uncovered recently:

- The bucket archive bson key `job_status` was changed to `status` months ago, but no migration was done, leaving affected buckets in a state where their `unspecified` current archive status was preventing a new archive from being triggered.
- Hub's Powergate was reset at some point, loosing old archive data. This resulted in old bucket archive storage info from being looked up in Powergate during the creation of a new archive, so the process would fail.

There is one more issue I'm hoping to figure out today, old buckets not deleting, but still need more info from Cake and to do more research there. Maybe we just move forward with these current fixes for now.