### PR TITLE
feat(api): adds content-types for .svg and .json

### DIFF
--- a/gateway/ipfs.go
+++ b/gateway/ipfs.go
@@ -119,6 +119,10 @@ func detectReaderContentType(r io.Reader, pth string) (string, io.Reader, error)
 		return "text/css", reader, nil
 	case ".js":
 		return "application/javascript", reader, nil
+	case ".json":
+		return "application/json", reader, nil
+	case ".svg":
+		return "image/svg+xml", reader, nil
 	case ".txt", ".md":
 		return "text/plain", reader, nil
 	default:


### PR DESCRIPTION
in our app, .svg's were not displaying in img tags due to the
content-type returned by the server being `text/plain` instead of
`image/svg+xml`.

To fix, the gateway will return the appropriate content-type,
`image/svg+xml`, for .svg files. As a bonus, .json files will
return `application/json`.

referenced mime types from https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types